### PR TITLE
Feature/dr 447 notification preferences

### DIFF
--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -110,11 +110,14 @@ model UserSettings {
   currency String @default("USD")
   timezone String @default("UTC")
 
-  // Notification settings
+  // Notification settings (legacy toggles)
   dealAlerts    Boolean @default(true)
   tripReminders Boolean @default(true)
   priceAlerts   Boolean @default(true)
   newsletter    Boolean @default(false)
+
+  // Granular per-type per-channel notification preferences (DR-447)
+  notificationPreferences Json?
 
   // Privacy settings
   profileVisibility String  @default("public") // public, private
@@ -950,6 +953,10 @@ enum NotificationType {
   BOOKING_CANCELLED
   PAYMENT_RECEIVED
   PAYMENT_FAILED
+  REFUND_PROCESSED
+  PROMO_OFFER
+  PLATFORM_UPDATE
+  ACCOUNT_SECURITY
   PRICE_ALERT
   TRIP_REMINDER
   SYSTEM

--- a/payment/src/index.ts
+++ b/payment/src/index.ts
@@ -7,8 +7,8 @@ import databaseService from './services/DatabaseService';
 import paymentRoutes from './routes/payment';
 import { rawBodyMiddleware } from './middleware/rawBody';
 
-// Load environment variables
-dotenv.config();
+// Load environment variables (override: true ensures .env takes precedence over shell env vars)
+dotenv.config({ override: true });
 
 const app = express();
 const PORT = process.env.PORT || 3004;

--- a/user/src/routes/notificationPreferencesRoutes.ts
+++ b/user/src/routes/notificationPreferencesRoutes.ts
@@ -1,0 +1,91 @@
+import { Router, Response } from 'express';
+import { authenticateToken, AuthRequest } from '../middleware/auth';
+import { prisma } from '@dreamscape/db';
+import {
+  NotificationPreferences,
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  PREFERENCE_KEYS,
+} from '../types/notificationPreferences';
+
+const router = Router();
+
+/**
+ * Validate that the body matches NotificationPreferences shape.
+ * Returns a cleaned object or null if invalid.
+ */
+function validatePreferences(body: unknown): NotificationPreferences | null {
+  if (!body || typeof body !== 'object') return null;
+
+  const result: Record<string, { inApp: boolean; email: boolean }> = {};
+
+  for (const key of PREFERENCE_KEYS) {
+    const entry = (body as Record<string, unknown>)[key];
+    if (!entry || typeof entry !== 'object') return null;
+
+    const { inApp, email } = entry as Record<string, unknown>;
+    if (typeof inApp !== 'boolean' || typeof email !== 'boolean') return null;
+
+    result[key] = { inApp, email };
+  }
+
+  return result as unknown as NotificationPreferences;
+}
+
+/**
+ * GET /api/v1/users/notification-preferences
+ * Returns the user's notification preferences or defaults if not yet set.
+ */
+router.get('/', authenticateToken, async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user!.id;
+
+    const settings = await prisma.userSettings.findUnique({
+      where: { userId },
+      select: { notificationPreferences: true },
+    });
+
+    const prefs = (settings?.notificationPreferences as NotificationPreferences | null)
+      ?? DEFAULT_NOTIFICATION_PREFERENCES;
+
+    res.json({ success: true, data: prefs });
+  } catch (error) {
+    console.error('[NotificationPreferencesRoutes] GET / error:', error);
+    res.status(500).json({ success: false, message: 'Failed to fetch notification preferences' });
+  }
+});
+
+/**
+ * PUT /api/v1/users/notification-preferences
+ * Validates and upserts notification preferences into UserSettings.
+ */
+router.put('/', authenticateToken, async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user!.id;
+    const validated = validatePreferences(req.body);
+
+    if (!validated) {
+      res.status(400).json({
+        success: false,
+        message: 'Invalid notification preferences. Expected keys: ' + PREFERENCE_KEYS.join(', ') +
+          ', each with { inApp: boolean, email: boolean }.',
+      });
+      return;
+    }
+
+    await prisma.userSettings.upsert({
+      where: { userId },
+      update: { notificationPreferences: validated as unknown as Record<string, unknown> },
+      create: {
+        userId,
+        notificationPreferences: validated as unknown as Record<string, unknown>,
+      },
+    });
+
+    res.json({ success: true, data: validated });
+  } catch (error) {
+    console.error('[NotificationPreferencesRoutes] PUT / error:', error);
+    res.status(500).json({ success: false, message: 'Failed to update notification preferences' });
+  }
+});
+
+export default router;

--- a/user/src/server.ts
+++ b/user/src/server.ts
@@ -18,6 +18,7 @@ import favoritesRoutes from './routes/favorites';
 import historyRoutes from '@routes/history';
 import gdprRoutes from './routes/gdpr';
 import notificationRoutes from './routes/notificationRoutes';
+import notificationPreferencesRoutes from './routes/notificationPreferencesRoutes';
 import { socketService } from './services/SocketService';
 import notificationService from './services/NotificationService';
 import { auditLogger } from './middleware/auditLogger';
@@ -78,6 +79,7 @@ app.use('/api/v1/ai', aiIntegrationRoutes);
 app.use('/api/v1/users/favorites', favoritesRoutes);
 app.use('/api/v1/users/gdpr', gdprRoutes);
 app.use('/api/v1/users/notifications', notificationRoutes);
+app.use('/api/v1/users/notification-preferences', notificationPreferencesRoutes);
 
 // Health check routes - INFRA-013.1
 app.use('/health', healthRoutes);

--- a/user/src/server.ts
+++ b/user/src/server.ts
@@ -155,10 +155,10 @@ const startServer = async () => {
         const secret = process.env.JWT_SECRET;
         if (!secret) return next(new Error('Server misconfiguration'));
 
-        const decoded = jwt.verify(token, secret) as { id: string; type?: string };
+        const decoded = jwt.verify(token, secret) as { userId: string; type?: string };
         if (decoded.type !== 'access') return next(new Error('Invalid token type'));
 
-        socket.data.userId = decoded.id;
+        socket.data.userId = decoded.userId;
         next();
       } catch {
         next(new Error('Invalid token'));

--- a/user/src/services/KafkaService.ts
+++ b/user/src/services/KafkaService.ts
@@ -311,6 +311,33 @@ class UserKafkaService {
   }
 
   /**
+   * Publish notification email requested event (DR-447)
+   */
+  async publishNotificationEmailRequested(payload: {
+    notificationId?: string;
+    userId: string;
+    type: string;
+    title: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+    requestedAt: string;
+  }): Promise<void> {
+    if (!this.client) {
+      console.warn('[UserKafkaService] Client not initialized, skipping publish');
+      return;
+    }
+
+    const event = createEvent(
+      'notification.email.requested',
+      SERVICE_NAME,
+      payload,
+    );
+
+    await this.client.publish(KAFKA_TOPICS.NOTIFICATION_EMAIL_REQUESTED, event, payload.userId);
+    console.log(`[UserKafkaService] Published notification email requested event for user: ${payload.userId}`);
+  }
+
+  /**
    * Health check for Kafka connection
    */
   async healthCheck(): Promise<{ healthy: boolean; details: Record<string, unknown> }> {

--- a/user/src/services/NotificationService.ts
+++ b/user/src/services/NotificationService.ts
@@ -1,6 +1,12 @@
 import { prisma } from '@dreamscape/db';
 import { socketService } from './SocketService';
 import { userKafkaService } from './KafkaService';
+import {
+  NotificationPreferences,
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  NOTIFICATION_TYPE_TO_PREF_KEY,
+  ALWAYS_ON_TYPES,
+} from '../types/notificationPreferences';
 
 type NotificationFilter = 'all' | 'unread' | 'read';
 
@@ -62,6 +68,36 @@ class NotificationService {
     });
   }
 
+  /**
+   * Check whether a notification should be sent for a given type and channel.
+   * Always-on types (ACCOUNT_SECURITY, SYSTEM, PRICE_ALERT, TRIP_REMINDER) always return true.
+   */
+  async shouldSend(
+    userId: string,
+    type: string,
+    channel: 'inApp' | 'email',
+  ): Promise<boolean> {
+    if (ALWAYS_ON_TYPES.has(type)) return true;
+
+    const prefKey = NOTIFICATION_TYPE_TO_PREF_KEY[type];
+    if (!prefKey) return true; // Unknown type — default to sending
+
+    try {
+      const settings = await prisma.userSettings.findUnique({
+        where: { userId },
+        select: { notificationPreferences: true },
+      });
+
+      const prefs = (settings?.notificationPreferences as NotificationPreferences | null)
+        ?? DEFAULT_NOTIFICATION_PREFERENCES;
+
+      return prefs[prefKey]?.[channel] ?? true;
+    } catch (error) {
+      console.error('[NotificationService] shouldSend error, defaulting to true:', error);
+      return true;
+    }
+  }
+
   async createNotification(
     userId: string,
     data: {
@@ -71,10 +107,34 @@ class NotificationService {
       metadata?: Record<string, unknown>;
     },
   ) {
+    const notificationType = data.type ?? 'SYSTEM';
+
+    // Check in-app preference before creating
+    const shouldCreateInApp = await this.shouldSend(userId, notificationType, 'inApp');
+    if (!shouldCreateInApp) {
+      // Still check if email should be sent even if in-app is disabled
+      const shouldSendEmail = await this.shouldSend(userId, notificationType, 'email');
+      if (shouldSendEmail) {
+        userKafkaService
+          .publishNotificationEmailRequested({
+            userId,
+            type: notificationType,
+            title: data.title,
+            message: data.message,
+            metadata: data.metadata,
+            requestedAt: new Date().toISOString(),
+          })
+          .catch((err) =>
+            console.error('[NotificationService] Kafka email request publish error:', err),
+          );
+      }
+      return null;
+    }
+
     const notification = await prisma.notification.create({
       data: {
         userId,
-        type: (data.type as never) ?? 'SYSTEM',
+        type: (notificationType as never) ?? 'SYSTEM',
         title: data.title,
         message: data.message,
         metadata: data.metadata ? JSON.parse(JSON.stringify(data.metadata)) : undefined,
@@ -97,6 +157,24 @@ class NotificationService {
       .catch((err) =>
         console.error('[NotificationService] Kafka publish error:', err),
       );
+
+    // Check email preference and emit email request if enabled (DR-447)
+    const shouldSendEmail = await this.shouldSend(userId, notificationType, 'email');
+    if (shouldSendEmail) {
+      userKafkaService
+        .publishNotificationEmailRequested({
+          notificationId: notification.id,
+          userId,
+          type: notificationType,
+          title: data.title,
+          message: data.message,
+          metadata: data.metadata,
+          requestedAt: new Date().toISOString(),
+        })
+        .catch((err) =>
+          console.error('[NotificationService] Kafka email request publish error:', err),
+        );
+    }
 
     return notification;
   }

--- a/user/src/types/notificationPreferences.ts
+++ b/user/src/types/notificationPreferences.ts
@@ -1,0 +1,68 @@
+/**
+ * DR-447 — Granular per-type, per-channel notification preferences.
+ *
+ * Stored as JSON in UserSettings.notificationPreferences.
+ * Types NOT listed here are "always-on" and cannot be disabled:
+ *   ACCOUNT_SECURITY, SYSTEM, PRICE_ALERT, TRIP_REMINDER
+ */
+
+export interface ChannelPreference {
+  inApp: boolean;
+  email: boolean;
+}
+
+export interface NotificationPreferences {
+  booking_confirmed: ChannelPreference;
+  booking_cancelled: ChannelPreference;
+  payment_succeeded: ChannelPreference;
+  payment_failed: ChannelPreference;
+  refund_processed: ChannelPreference;
+  promo_offer: ChannelPreference;
+  platform_update: ChannelPreference;
+}
+
+export type NotificationPreferenceKey = keyof NotificationPreferences;
+
+/** Default preferences — all in-app enabled; email enabled except promo & platform. */
+export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
+  booking_confirmed: { inApp: true, email: true },
+  booking_cancelled: { inApp: true, email: true },
+  payment_succeeded: { inApp: true, email: true },
+  payment_failed: { inApp: true, email: true },
+  refund_processed: { inApp: true, email: true },
+  promo_offer: { inApp: true, email: false },
+  platform_update: { inApp: true, email: false },
+};
+
+/** All valid preference keys (used for validation). */
+export const PREFERENCE_KEYS: NotificationPreferenceKey[] = [
+  'booking_confirmed',
+  'booking_cancelled',
+  'payment_succeeded',
+  'payment_failed',
+  'refund_processed',
+  'promo_offer',
+  'platform_update',
+];
+
+/**
+ * Map Prisma NotificationType enum values to preference keys.
+ * Types not in this map are always-on (ACCOUNT_SECURITY, SYSTEM, PRICE_ALERT, TRIP_REMINDER).
+ */
+export const NOTIFICATION_TYPE_TO_PREF_KEY: Record<string, NotificationPreferenceKey> = {
+  BOOKING_CONFIRMED: 'booking_confirmed',
+  BOOKING_CANCELLED: 'booking_cancelled',
+  PAYMENT_RECEIVED: 'payment_succeeded',
+  PAYMENT_FAILED: 'payment_failed',
+  REFUND_PROCESSED: 'refund_processed',
+  PROMO_OFFER: 'promo_offer',
+  PLATFORM_UPDATE: 'platform_update',
+};
+
+/** Types that are always sent regardless of user preferences. */
+export const ALWAYS_ON_TYPES = new Set([
+  'ACCOUNT_SECURITY',
+  'SYSTEM',
+  'PRICE_ALERT',
+  'TRIP_REMINDER',
+]);


### PR DESCRIPTION
## DR-447 - Préférences de Notifications

  ### Backend Changes

  **Schema Prisma :**
  - Ajout du champ `notificationPreferences Json?` sur `UserSettings`
  - Ajout de 4 types à l'enum `NotificationType` : `REFUND_PROCESSED`,
  `PROMO_OFFER`, `PLATFORM_UPDATE`, `ACCOUNT_SECURITY`

  **API :**
  - `GET /api/v1/users/notification-preferences` — retourne les préférences ou 
  les defaults
  - `PUT /api/v1/users/notification-preferences` — valide et sauvegarde les    
  préférences par type × canal (inApp/email)

  **NotificationService :**
  - Méthode `shouldSend(userId, type, channel)` pour vérifier les préférences  
  avant envoi
  - Les types always-on (ACCOUNT_SECURITY, SYSTEM, PRICE_ALERT, TRIP_REMINDER) 
  bypassed les préférences
  - Emission Kafka `notification.email.requested` uniquement si le canal email 
  est activé

  **Fix Socket.io :**
  - Correction du champ JWT `decoded.id` → `decoded.userId` pour que les       
  notifications temps réel fonctionnent

  **Commentaire laissé sur DR-445** (ticket EmailService de Nicolas) avec le   
  payload Kafka et les instructions d'intégration.