### PR TITLE
feat(user): add admin dashboard API endpoints (US-ADMIN-001)

### DIFF
--- a/db/seed_admin_demo.ts
+++ b/db/seed_admin_demo.ts
@@ -1,0 +1,214 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🌱 Seeding demo bookings & payments...');
+
+  // Get first user in DB (your admin account)
+  const users = await prisma.user.findMany({ take: 3, orderBy: { createdAt: 'asc' } });
+  if (users.length === 0) {
+    console.error('❌ No users found. Create an account first.');
+    return;
+  }
+
+  // Use up to 3 users, cycling if fewer
+  const getUser = (i: number) => users[i % users.length];
+
+  // Clean existing demo bookings/payments to avoid duplicates
+  await prisma.paymentTransaction.deleteMany({
+    where: { bookingReference: { startsWith: 'DEMO-' } },
+  });
+  await prisma.bookingData.deleteMany({
+    where: { reference: { startsWith: 'DEMO-' } },
+  });
+
+  console.log(`👤 Using ${users.length} user(s): ${users.map(u => u.email).join(', ')}`);
+
+  const now = new Date();
+  const daysAgo = (n: number) => new Date(now.getTime() - n * 24 * 60 * 60 * 1000);
+
+  // ---- BOOKINGS ----
+  const bookingsData = [
+    {
+      userId: getUser(0).id,
+      type: 'FLIGHT' as const,
+      reference: 'DEMO-FLT-001',
+      status: 'CONFIRMED' as const,
+      totalAmount: 349.90,
+      currency: 'EUR',
+      confirmedAt: daysAgo(5),
+      createdAt: daysAgo(6),
+      data: { from: 'CDG', to: 'JFK', departure: '2026-04-15T08:00:00Z', passengers: 2 },
+    },
+    {
+      userId: getUser(0).id,
+      type: 'HOTEL' as const,
+      reference: 'DEMO-HTL-001',
+      status: 'COMPLETED' as const,
+      totalAmount: 520.00,
+      currency: 'EUR',
+      confirmedAt: daysAgo(20),
+      createdAt: daysAgo(22),
+      data: { hotel: 'Le Meurice Paris', checkIn: '2026-03-01', checkOut: '2026-03-04', rooms: 1 },
+    },
+    {
+      userId: getUser(1).id,
+      type: 'PACKAGE' as const,
+      reference: 'DEMO-PKG-001',
+      status: 'PENDING' as const,
+      totalAmount: 1250.00,
+      currency: 'EUR',
+      confirmedAt: null,
+      createdAt: daysAgo(2),
+      data: { destination: 'Bali', duration: '7 nuits', included: ['vol', 'hôtel', 'transfert'] },
+    },
+    {
+      userId: getUser(1).id,
+      type: 'ACTIVITY' as const,
+      reference: 'DEMO-ACT-001',
+      status: 'CONFIRMED' as const,
+      totalAmount: 89.00,
+      currency: 'EUR',
+      confirmedAt: daysAgo(1),
+      createdAt: daysAgo(3),
+      data: { activity: 'Tour Eiffel - Accès sommet', date: '2026-04-20', participants: 2 },
+    },
+    {
+      userId: getUser(2).id,
+      type: 'TRANSFER' as const,
+      reference: 'DEMO-TRF-001',
+      status: 'CANCELLED' as const,
+      totalAmount: 75.00,
+      currency: 'EUR',
+      confirmedAt: null,
+      createdAt: daysAgo(10),
+      data: { from: 'CDG', to: 'Paris Centre', type: 'VTC', passengers: 3 },
+    },
+    {
+      userId: getUser(0).id,
+      type: 'FLIGHT' as const,
+      reference: 'DEMO-FLT-002',
+      status: 'PENDING_PAYMENT' as const,
+      totalAmount: 210.50,
+      currency: 'EUR',
+      confirmedAt: null,
+      createdAt: daysAgo(1),
+      data: { from: 'ORY', to: 'BCN', departure: '2026-05-10T06:30:00Z', passengers: 1 },
+    },
+    {
+      userId: getUser(1).id,
+      type: 'HOTEL' as const,
+      reference: 'DEMO-HTL-002',
+      status: 'CONFIRMED' as const,
+      totalAmount: 890.00,
+      currency: 'EUR',
+      confirmedAt: daysAgo(4),
+      createdAt: daysAgo(5),
+      data: { hotel: 'W Barcelona', checkIn: '2026-05-10', checkOut: '2026-05-14', rooms: 1 },
+    },
+    {
+      userId: getUser(2).id,
+      type: 'PACKAGE' as const,
+      reference: 'DEMO-PKG-002',
+      status: 'FAILED' as const,
+      totalAmount: 3200.00,
+      currency: 'EUR',
+      confirmedAt: null,
+      createdAt: daysAgo(8),
+      data: { destination: 'Maldives', duration: '10 nuits', included: ['vol first class', 'resort 5*'] },
+    },
+  ];
+
+  const createdBookings: any[] = [];
+  for (const b of bookingsData) {
+    const booking = await prisma.bookingData.create({ data: b as any });
+    createdBookings.push(booking);
+    console.log(`  ✅ Booking ${booking.reference} (${booking.status})`);
+  }
+
+  // ---- PAYMENT TRANSACTIONS ----
+  const paymentsData = [
+    {
+      bookingIndex: 0, // DEMO-FLT-001 CONFIRMED
+      paymentIntentId: 'pi_demo_flt001_succeeded',
+      status: 'SUCCEEDED' as const,
+      paymentMethod: 'card',
+      confirmedAt: daysAgo(5),
+      createdAt: daysAgo(6),
+    },
+    {
+      bookingIndex: 1, // DEMO-HTL-001 COMPLETED
+      paymentIntentId: 'pi_demo_htl001_succeeded',
+      status: 'SUCCEEDED' as const,
+      paymentMethod: 'card',
+      confirmedAt: daysAgo(20),
+      createdAt: daysAgo(22),
+    },
+    {
+      bookingIndex: 3, // DEMO-ACT-001 CONFIRMED
+      paymentIntentId: 'pi_demo_act001_succeeded',
+      status: 'SUCCEEDED' as const,
+      paymentMethod: 'apple_pay',
+      confirmedAt: daysAgo(1),
+      createdAt: daysAgo(3),
+    },
+    {
+      bookingIndex: 4, // DEMO-TRF-001 CANCELLED
+      paymentIntentId: 'pi_demo_trf001_refunded',
+      status: 'REFUNDED' as const,
+      paymentMethod: 'card',
+      confirmedAt: daysAgo(9),
+      refundedAt: daysAgo(8),
+      createdAt: daysAgo(10),
+    },
+    {
+      bookingIndex: 5, // DEMO-FLT-002 PENDING_PAYMENT
+      paymentIntentId: 'pi_demo_flt002_pending',
+      status: 'PENDING' as const,
+      paymentMethod: null,
+      createdAt: daysAgo(1),
+    },
+    {
+      bookingIndex: 6, // DEMO-HTL-002 CONFIRMED
+      paymentIntentId: 'pi_demo_htl002_succeeded',
+      status: 'SUCCEEDED' as const,
+      paymentMethod: 'google_pay',
+      confirmedAt: daysAgo(4),
+      createdAt: daysAgo(5),
+    },
+    {
+      bookingIndex: 7, // DEMO-PKG-002 FAILED
+      paymentIntentId: 'pi_demo_pkg002_failed',
+      status: 'FAILED' as const,
+      paymentMethod: 'card',
+      failureReason: 'insufficient_funds',
+      failedAt: daysAgo(8),
+      createdAt: daysAgo(8),
+      metadata: { declineCode: 'insufficient_funds', network: 'visa' },
+    },
+  ];
+
+  for (const p of paymentsData) {
+    const booking = createdBookings[p.bookingIndex];
+    const { bookingIndex, ...paymentData } = p;
+    await prisma.paymentTransaction.create({
+      data: {
+        ...paymentData,
+        bookingId: booking.id,
+        bookingReference: booking.reference,
+        userId: booking.userId,
+        amount: booking.totalAmount,
+        currency: booking.currency,
+      } as any,
+    });
+    console.log(`  💳 Payment ${paymentData.paymentIntentId} (${paymentData.status})`);
+  }
+
+  console.log('\n✅ Demo seed complete!');
+  console.log(`   ${createdBookings.length} bookings + ${paymentsData.length} payments created`);
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/user/src/controllers/adminBookingController.ts
+++ b/user/src/controllers/adminBookingController.ts
@@ -1,0 +1,93 @@
+import { Response } from 'express';
+import { AuthRequest } from '@middleware/auth';
+import * as AdminBookingService from '../services/AdminBookingService';
+
+const sendError = (res: Response, status: number, message: string): void => {
+  res.status(status).json({ success: false, message });
+};
+
+const sendSuccess = (res: Response, data: any): void => {
+  res.json({ success: true, data });
+};
+
+export const listBookings = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const search = req.query.search as string | undefined;
+    const status = req.query.status as string | undefined;
+    const type = req.query.type as string | undefined;
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+    const sortBy = req.query.sortBy as string || 'createdAt';
+    const sortOrder = (req.query.sortOrder as string) === 'asc' ? 'asc' : 'desc';
+
+    const result = await AdminBookingService.listBookings({
+      page, limit, search, status, type, startDate, endDate, sortBy, sortOrder,
+    });
+    sendSuccess(res, result);
+  } catch (error: any) {
+    console.error('Error listing bookings:', error);
+    sendError(res, 500, error.message || 'Failed to list bookings');
+  }
+};
+
+export const getBooking = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const booking = await AdminBookingService.getBookingById(req.params.id);
+    sendSuccess(res, booking);
+  } catch (error: any) {
+    if (error.message === 'Booking not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    console.error('Error fetching booking:', error);
+    sendError(res, 500, error.message || 'Failed to fetch booking');
+  }
+};
+
+export const updateBookingStatus = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { status } = req.body;
+    if (!status) {
+      sendError(res, 400, 'Status is required');
+      return;
+    }
+    const booking = await AdminBookingService.updateBookingStatus(req.params.id, status);
+    sendSuccess(res, booking);
+  } catch (error: any) {
+    if (error.message === 'Booking not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    if (error.message === 'Invalid status') {
+      sendError(res, 400, error.message);
+      return;
+    }
+    console.error('Error updating booking status:', error);
+    sendError(res, 500, error.message || 'Failed to update booking status');
+  }
+};
+
+export const bulkUpdateBookingStatus = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { ids, status } = req.body;
+    if (!ids || !Array.isArray(ids) || ids.length === 0) {
+      sendError(res, 400, 'ids array is required');
+      return;
+    }
+    if (!status) {
+      sendError(res, 400, 'Status is required');
+      return;
+    }
+    const result = await AdminBookingService.bulkUpdateBookingStatus(ids, status);
+    sendSuccess(res, result);
+  } catch (error: any) {
+    if (error.message === 'Invalid status') {
+      sendError(res, 400, error.message);
+      return;
+    }
+    console.error('Error bulk updating booking statuses:', error);
+    sendError(res, 500, error.message || 'Failed to bulk update');
+  }
+};

--- a/user/src/controllers/adminDashboardController.ts
+++ b/user/src/controllers/adminDashboardController.ts
@@ -1,0 +1,63 @@
+import { Response } from 'express';
+import { AuthRequest } from '@middleware/auth';
+import * as AdminDashboardService from '../services/AdminDashboardService';
+
+const sendError = (res: Response, status: number, message: string): void => {
+  res.status(status).json({ success: false, message });
+};
+
+const sendSuccess = (res: Response, data: any): void => {
+  res.json({ success: true, data });
+};
+
+export const getDashboardStats = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const periodParam = (req.query.period as string) || '7d';
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+
+    const period = AdminDashboardService.parsePeriod(periodParam, startDate, endDate);
+    const stats = await AdminDashboardService.getStats(period);
+    sendSuccess(res, stats);
+  } catch (error: any) {
+    console.error('Error fetching dashboard stats:', error);
+    sendError(res, 500, error.message || 'Failed to fetch dashboard stats');
+  }
+};
+
+export const getRevenueChart = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const periodParam = (req.query.period as string) || '7d';
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+
+    const period = AdminDashboardService.parsePeriod(periodParam, startDate, endDate);
+    const chart = await AdminDashboardService.getRevenueChart(period);
+    sendSuccess(res, chart);
+  } catch (error: any) {
+    console.error('Error fetching revenue chart:', error);
+    sendError(res, 500, error.message || 'Failed to fetch revenue chart');
+  }
+};
+
+export const getBookingsByDestination = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const limit = parseInt(req.query.limit as string) || 5;
+    const data = await AdminDashboardService.getBookingsByDestination(limit);
+    sendSuccess(res, data);
+  } catch (error: any) {
+    console.error('Error fetching bookings by destination:', error);
+    sendError(res, 500, error.message || 'Failed to fetch bookings by destination');
+  }
+};
+
+export const getRecentTransactions = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const limit = parseInt(req.query.limit as string) || 10;
+    const data = await AdminDashboardService.getRecentTransactions(limit);
+    sendSuccess(res, data);
+  } catch (error: any) {
+    console.error('Error fetching recent transactions:', error);
+    sendError(res, 500, error.message || 'Failed to fetch recent transactions');
+  }
+};

--- a/user/src/controllers/adminDashboardController.ts
+++ b/user/src/controllers/adminDashboardController.ts
@@ -43,7 +43,12 @@ export const getRevenueChart = async (req: AuthRequest, res: Response): Promise<
 export const getBookingsByDestination = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const limit = parseInt(req.query.limit as string) || 5;
-    const data = await AdminDashboardService.getBookingsByDestination(limit);
+    const periodParam = (req.query.period as string) || '7d';
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+
+    const period = AdminDashboardService.parsePeriod(periodParam, startDate, endDate);
+    const data = await AdminDashboardService.getBookingsByDestination(limit, period);
     sendSuccess(res, data);
   } catch (error: any) {
     console.error('Error fetching bookings by destination:', error);
@@ -54,7 +59,12 @@ export const getBookingsByDestination = async (req: AuthRequest, res: Response):
 export const getRecentTransactions = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const limit = parseInt(req.query.limit as string) || 10;
-    const data = await AdminDashboardService.getRecentTransactions(limit);
+    const periodParam = (req.query.period as string) || '7d';
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+
+    const period = AdminDashboardService.parsePeriod(periodParam, startDate, endDate);
+    const data = await AdminDashboardService.getRecentTransactions(limit, period);
     sendSuccess(res, data);
   } catch (error: any) {
     console.error('Error fetching recent transactions:', error);

--- a/user/src/controllers/adminPaymentController.ts
+++ b/user/src/controllers/adminPaymentController.ts
@@ -1,0 +1,71 @@
+import { Response } from 'express';
+import { AuthRequest } from '@middleware/auth';
+import * as AdminPaymentService from '../services/AdminPaymentService';
+
+const sendError = (res: Response, status: number, message: string): void => {
+  res.status(status).json({ success: false, message });
+};
+
+const sendSuccess = (res: Response, data: any): void => {
+  res.json({ success: true, data });
+};
+
+export const listPayments = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const search = req.query.search as string | undefined;
+    const status = req.query.status as string | undefined;
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+    const minAmount = req.query.minAmount ? parseFloat(req.query.minAmount as string) : undefined;
+    const maxAmount = req.query.maxAmount ? parseFloat(req.query.maxAmount as string) : undefined;
+    const sortBy = req.query.sortBy as string || 'createdAt';
+    const sortOrder = (req.query.sortOrder as string) === 'asc' ? 'asc' : 'desc';
+
+    const result = await AdminPaymentService.listPayments({
+      page, limit, search, status, startDate, endDate, minAmount, maxAmount, sortBy, sortOrder,
+    });
+    sendSuccess(res, result);
+  } catch (error: any) {
+    console.error('Error listing payments:', error);
+    sendError(res, 500, error.message || 'Failed to list payments');
+  }
+};
+
+export const getPayment = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const payment = await AdminPaymentService.getPaymentById(req.params.id);
+    sendSuccess(res, payment);
+  } catch (error: any) {
+    if (error.message === 'Payment not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    console.error('Error fetching payment:', error);
+    sendError(res, 500, error.message || 'Failed to fetch payment');
+  }
+};
+
+export const updatePaymentStatus = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { status } = req.body;
+    if (!status) {
+      sendError(res, 400, 'Status is required');
+      return;
+    }
+    const payment = await AdminPaymentService.updatePaymentStatus(req.params.id, status);
+    sendSuccess(res, payment);
+  } catch (error: any) {
+    if (error.message === 'Payment not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    if (error.message === 'Invalid status') {
+      sendError(res, 400, error.message);
+      return;
+    }
+    console.error('Error updating payment status:', error);
+    sendError(res, 500, error.message || 'Failed to update payment status');
+  }
+};

--- a/user/src/controllers/adminUserController.ts
+++ b/user/src/controllers/adminUserController.ts
@@ -1,0 +1,81 @@
+import { Response } from 'express';
+import { AuthRequest } from '@middleware/auth';
+import * as AdminUserService from '../services/AdminUserService';
+
+const sendError = (res: Response, status: number, message: string): void => {
+  res.status(status).json({ success: false, message });
+};
+
+const sendSuccess = (res: Response, data: any): void => {
+  res.json({ success: true, data });
+};
+
+export const listUsers = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const search = req.query.search as string | undefined;
+    const role = req.query.role as string | undefined;
+    const sortBy = req.query.sortBy as string || 'createdAt';
+    const sortOrder = (req.query.sortOrder as string) === 'asc' ? 'asc' : 'desc';
+
+    const result = await AdminUserService.listUsers({ page, limit, search, role, sortBy, sortOrder });
+    sendSuccess(res, result);
+  } catch (error: any) {
+    console.error('Error listing users:', error);
+    sendError(res, 500, error.message || 'Failed to list users');
+  }
+};
+
+export const getUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const user = await AdminUserService.getUserById(req.params.id);
+    sendSuccess(res, user);
+  } catch (error: any) {
+    if (error.message === 'User not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    console.error('Error fetching user:', error);
+    sendError(res, 500, error.message || 'Failed to fetch user');
+  }
+};
+
+export const updateUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { firstName, lastName, email, role, isVerified, userCategory } = req.body;
+    const user = await AdminUserService.updateUser(req.params.id, {
+      firstName, lastName, email, role, isVerified, userCategory,
+    });
+    sendSuccess(res, user);
+  } catch (error: any) {
+    if (error.message === 'User not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    if (error.message === 'Email already in use') {
+      sendError(res, 409, error.message);
+      return;
+    }
+    console.error('Error updating user:', error);
+    sendError(res, 500, error.message || 'Failed to update user');
+  }
+};
+
+export const deleteUser = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    if (req.params.id === req.user?.id) {
+      sendError(res, 400, 'Cannot delete your own account');
+      return;
+    }
+    const result = await AdminUserService.deleteUser(req.params.id);
+    sendSuccess(res, result);
+  } catch (error: any) {
+    if (error.message === 'User not found') {
+      sendError(res, 404, error.message);
+      return;
+    }
+    console.error('Error deleting user:', error);
+    sendError(res, 500, error.message || 'Failed to delete user');
+  }
+};

--- a/user/src/middleware/auth.ts
+++ b/user/src/middleware/auth.ts
@@ -6,6 +6,7 @@ export interface AuthRequest extends Request {
   user?: {
     id: string;
     email: string;
+    role: string;
   };
 }
 
@@ -69,7 +70,7 @@ export const authenticateToken = async (
     // Verify user still exists
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },
-      select: { id: true, email: true }
+      select: { id: true, email: true, role: true }
     });
 
     if (!user) {
@@ -133,7 +134,7 @@ export const optionalAuth = async (
     if (decoded.type === 'access') {
       const user = await prisma.user.findUnique({
         where: { id: decoded.userId },
-        select: { id: true, email: true }
+        select: { id: true, email: true, role: true }
       });
 
       if (user) {

--- a/user/src/middleware/requireAdmin.ts
+++ b/user/src/middleware/requireAdmin.ts
@@ -1,0 +1,18 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth';
+
+export const requireAdmin = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (!req.user) {
+    res.status(401).json({ success: false, message: 'Authentication required' });
+    return;
+  }
+  if (req.user.role !== 'ADMIN') {
+    res.status(403).json({ success: false, message: 'Admin access required' });
+    return;
+  }
+  next();
+};

--- a/user/src/routes/admin.ts
+++ b/user/src/routes/admin.ts
@@ -3,6 +3,8 @@ import { authenticateToken } from '@middleware/auth';
 import { requireAdmin } from '@middleware/requireAdmin';
 import * as dashboardCtrl from '../controllers/adminDashboardController';
 import * as userCtrl from '../controllers/adminUserController';
+import * as bookingCtrl from '../controllers/adminBookingController';
+import * as paymentCtrl from '../controllers/adminPaymentController';
 
 const router = Router();
 
@@ -19,5 +21,16 @@ router.get('/users', userCtrl.listUsers);
 router.get('/users/:id', userCtrl.getUser);
 router.put('/users/:id', userCtrl.updateUser);
 router.delete('/users/:id', userCtrl.deleteUser);
+
+// Bookings
+router.get('/bookings', bookingCtrl.listBookings);
+router.get('/bookings/:id', bookingCtrl.getBooking);
+router.put('/bookings/:id/status', bookingCtrl.updateBookingStatus);
+router.put('/bookings/bulk/status', bookingCtrl.bulkUpdateBookingStatus);
+
+// Payments
+router.get('/payments', paymentCtrl.listPayments);
+router.get('/payments/:id', paymentCtrl.getPayment);
+router.put('/payments/:id/status', paymentCtrl.updatePaymentStatus);
 
 export default router;

--- a/user/src/routes/admin.ts
+++ b/user/src/routes/admin.ts
@@ -1,15 +1,23 @@
 import { Router } from 'express';
 import { authenticateToken } from '@middleware/auth';
 import { requireAdmin } from '@middleware/requireAdmin';
-import * as ctrl from '../controllers/adminDashboardController';
+import * as dashboardCtrl from '../controllers/adminDashboardController';
+import * as userCtrl from '../controllers/adminUserController';
 
 const router = Router();
 
 router.use(authenticateToken, requireAdmin);
 
-router.get('/dashboard/stats', ctrl.getDashboardStats);
-router.get('/dashboard/revenue-chart', ctrl.getRevenueChart);
-router.get('/dashboard/bookings-by-destination', ctrl.getBookingsByDestination);
-router.get('/dashboard/recent-transactions', ctrl.getRecentTransactions);
+// Dashboard
+router.get('/dashboard/stats', dashboardCtrl.getDashboardStats);
+router.get('/dashboard/revenue-chart', dashboardCtrl.getRevenueChart);
+router.get('/dashboard/bookings-by-destination', dashboardCtrl.getBookingsByDestination);
+router.get('/dashboard/recent-transactions', dashboardCtrl.getRecentTransactions);
+
+// Users CRUD
+router.get('/users', userCtrl.listUsers);
+router.get('/users/:id', userCtrl.getUser);
+router.put('/users/:id', userCtrl.updateUser);
+router.delete('/users/:id', userCtrl.deleteUser);
 
 export default router;

--- a/user/src/routes/admin.ts
+++ b/user/src/routes/admin.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { authenticateToken } from '@middleware/auth';
+import { requireAdmin } from '@middleware/requireAdmin';
+import * as ctrl from '../controllers/adminDashboardController';
+
+const router = Router();
+
+router.use(authenticateToken, requireAdmin);
+
+router.get('/dashboard/stats', ctrl.getDashboardStats);
+router.get('/dashboard/revenue-chart', ctrl.getRevenueChart);
+router.get('/dashboard/bookings-by-destination', ctrl.getBookingsByDestination);
+router.get('/dashboard/recent-transactions', ctrl.getRecentTransactions);
+
+export default router;

--- a/user/src/server.ts
+++ b/user/src/server.ts
@@ -19,6 +19,7 @@ import historyRoutes from '@routes/history';
 import gdprRoutes from './routes/gdpr';
 import notificationRoutes from './routes/notificationRoutes';
 import notificationPreferencesRoutes from './routes/notificationPreferencesRoutes';
+import adminRoutes from './routes/admin';
 import { socketService } from './services/SocketService';
 import notificationService from './services/NotificationService';
 import { auditLogger } from './middleware/auditLogger';
@@ -80,6 +81,7 @@ app.use('/api/v1/users/favorites', favoritesRoutes);
 app.use('/api/v1/users/gdpr', gdprRoutes);
 app.use('/api/v1/users/notifications', notificationRoutes);
 app.use('/api/v1/users/notification-preferences', notificationPreferencesRoutes);
+app.use('/api/v1/admin', adminRoutes);
 
 // Health check routes - INFRA-013.1
 app.use('/health', healthRoutes);

--- a/user/src/services/AdminBookingService.ts
+++ b/user/src/services/AdminBookingService.ts
@@ -1,0 +1,144 @@
+import { prisma } from '@dreamscape/db';
+
+interface ListBookingsParams {
+  page: number;
+  limit: number;
+  search?: string;
+  status?: string;
+  type?: string;
+  startDate?: string;
+  endDate?: string;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+async function enrichWithUsers<T extends { userId: string }>(items: T[]) {
+  const userIds = [...new Set(items.map((i) => i.userId))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  return items.map((item) => ({ ...item, user: userMap.get(item.userId) ?? null }));
+}
+
+export async function listBookings(params: ListBookingsParams) {
+  const { page, limit, search, status, type, startDate, endDate, sortBy = 'createdAt', sortOrder = 'desc' } = params;
+  const skip = (page - 1) * limit;
+
+  const where: any = {};
+
+  if (status) where.status = status;
+  if (type) where.type = type;
+
+  if (startDate || endDate) {
+    where.createdAt = {};
+    if (startDate) where.createdAt.gte = new Date(startDate);
+    if (endDate) where.createdAt.lte = new Date(endDate);
+  }
+
+  // Search by reference first, then filter by user if needed
+  if (search) {
+    const matchingUsers = await prisma.user.findMany({
+      where: {
+        OR: [
+          { email: { contains: search, mode: 'insensitive' } },
+          { firstName: { contains: search, mode: 'insensitive' } },
+          { lastName: { contains: search, mode: 'insensitive' } },
+        ],
+      },
+      select: { id: true },
+    });
+    const userIds = matchingUsers.map((u) => u.id);
+
+    where.OR = [
+      { reference: { contains: search, mode: 'insensitive' } },
+      ...(userIds.length > 0 ? [{ userId: { in: userIds } }] : []),
+    ];
+  }
+
+  const [bookings, total] = await Promise.all([
+    prisma.bookingData.findMany({
+      where,
+      orderBy: { [sortBy]: sortOrder },
+      skip,
+      take: limit,
+    }),
+    prisma.bookingData.count({ where }),
+  ]);
+
+  const enriched = await enrichWithUsers(
+    bookings.map((b) => ({ ...b, totalAmount: Number(b.totalAmount) }))
+  );
+
+  return {
+    bookings: enriched,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
+}
+
+export async function getBookingById(id: string) {
+  const booking = await prisma.bookingData.findUnique({ where: { id } });
+  if (!booking) throw new Error('Booking not found');
+
+  const user = await prisma.user.findUnique({
+    where: { id: booking.userId },
+    select: { id: true, email: true, firstName: true, lastName: true, username: true },
+  });
+
+  let payment = null;
+  if (booking.paymentIntentId) {
+    const p = await prisma.paymentTransaction.findUnique({
+      where: { paymentIntentId: booking.paymentIntentId },
+    });
+    if (p) payment = { ...p, amount: Number(p.amount) };
+  }
+
+  return {
+    ...booking,
+    totalAmount: Number(booking.totalAmount),
+    user,
+    payment,
+  };
+}
+
+export async function updateBookingStatus(id: string, status: string) {
+  const existing = await prisma.bookingData.findUnique({ where: { id } });
+  if (!existing) throw new Error('Booking not found');
+
+  const validStatuses = ['DRAFT', 'PENDING_PAYMENT', 'PENDING', 'CONFIRMED', 'COMPLETED', 'CANCELLED', 'FAILED'];
+  if (!validStatuses.includes(status)) throw new Error('Invalid status');
+
+  const updateData: any = { status };
+  if (status === 'CONFIRMED' && !existing.confirmedAt) {
+    updateData.confirmedAt = new Date();
+  }
+
+  const booking = await prisma.bookingData.update({ where: { id }, data: updateData });
+  const user = await prisma.user.findUnique({
+    where: { id: booking.userId },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+
+  return { ...booking, totalAmount: Number(booking.totalAmount), user };
+}
+
+export async function bulkUpdateBookingStatus(ids: string[], status: string) {
+  const validStatuses = ['DRAFT', 'PENDING_PAYMENT', 'PENDING', 'CONFIRMED', 'COMPLETED', 'CANCELLED', 'FAILED'];
+  if (!validStatuses.includes(status)) throw new Error('Invalid status');
+
+  const updateData: any = { status };
+  if (status === 'CONFIRMED') updateData.confirmedAt = new Date();
+
+  await prisma.bookingData.updateMany({
+    where: { id: { in: ids } },
+    data: updateData,
+  });
+
+  return { updated: ids.length };
+}

--- a/user/src/services/AdminDashboardService.ts
+++ b/user/src/services/AdminDashboardService.ts
@@ -142,13 +142,13 @@ export async function getRevenueChart(period: Period) {
 
   const result = await prisma.$queryRaw<Array<{ date: Date; revenue: number }>>`
     SELECT
-      date_trunc('day', "created_at") as date,
+      date_trunc('day', "createdAt") as date,
       COALESCE(SUM(amount), 0)::float as revenue
     FROM payment_transactions
     WHERE status = 'SUCCEEDED'
-      AND "created_at" >= ${startDate}
-      AND "created_at" <= ${endDate}
-    GROUP BY date_trunc('day', "created_at")
+      AND "createdAt" >= ${startDate}
+      AND "createdAt" <= ${endDate}
+    GROUP BY date_trunc('day', "createdAt")
     ORDER BY date
   `;
 

--- a/user/src/services/AdminDashboardService.ts
+++ b/user/src/services/AdminDashboardService.ts
@@ -1,0 +1,207 @@
+import { prisma } from '@dreamscape/db';
+import { Prisma } from '@prisma/client';
+
+interface Period {
+  startDate: Date;
+  endDate: Date;
+  previousStartDate: Date;
+  previousEndDate: Date;
+}
+
+export function parsePeriod(period: string, startDate?: string, endDate?: string): Period {
+  const now = new Date();
+  let start: Date;
+  let end: Date = now;
+
+  switch (period) {
+    case '24h':
+      start = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      break;
+    case '7d':
+      start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case '30d':
+      start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+    case 'custom':
+      if (!startDate || !endDate) throw new Error('startDate and endDate required for custom period');
+      start = new Date(startDate);
+      end = new Date(endDate);
+      break;
+    default:
+      start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+
+  const duration = end.getTime() - start.getTime();
+  const previousEnd = new Date(start.getTime());
+  const previousStart = new Date(start.getTime() - duration);
+
+  return { startDate: start, endDate: end, previousStartDate: previousStart, previousEndDate: previousEnd };
+}
+
+export async function getStats(period: Period) {
+  const { startDate, endDate, previousStartDate, previousEndDate } = period;
+
+  // Users
+  const [totalUsers, activeUsers, newUsers, previousNewUsers] = await Promise.all([
+    prisma.user.count(),
+    prisma.user.count({ where: { isVerified: true } }),
+    prisma.user.count({ where: { createdAt: { gte: startDate, lte: endDate } } }),
+    prisma.user.count({ where: { createdAt: { gte: previousStartDate, lte: previousEndDate } } }),
+  ]);
+
+  // Bookings
+  const bookingWhere = { createdAt: { gte: startDate, lte: endDate } };
+  const previousBookingWhere = { createdAt: { gte: previousStartDate, lte: previousEndDate } };
+
+  const [totalBookings, previousTotalBookings, bookingsByStatus] = await Promise.all([
+    prisma.bookingData.count({ where: bookingWhere }),
+    prisma.bookingData.count({ where: previousBookingWhere }),
+    prisma.bookingData.groupBy({
+      by: ['status'],
+      where: bookingWhere,
+      _count: { id: true },
+    }),
+  ]);
+
+  // Revenue
+  const [revenueResult, previousRevenueResult] = await Promise.all([
+    prisma.paymentTransaction.aggregate({
+      where: { status: 'SUCCEEDED', createdAt: { gte: startDate, lte: endDate } },
+      _sum: { amount: true },
+    }),
+    prisma.paymentTransaction.aggregate({
+      where: { status: 'SUCCEEDED', createdAt: { gte: previousStartDate, lte: previousEndDate } },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  const revenue = Number(revenueResult._sum.amount || 0);
+  const previousRevenue = Number(previousRevenueResult._sum.amount || 0);
+
+  // Conversion rate: searches vs confirmed bookings
+  const [searchCount, confirmedBookings] = await Promise.all([
+    prisma.searchHistory.count({ where: { searchedAt: { gte: startDate, lte: endDate } } }),
+    prisma.bookingData.count({
+      where: {
+        ...bookingWhere,
+        status: { in: ['CONFIRMED', 'COMPLETED'] },
+      },
+    }),
+  ]);
+
+  const [previousSearchCount, previousConfirmedBookings] = await Promise.all([
+    prisma.searchHistory.count({ where: { searchedAt: { gte: previousStartDate, lte: previousEndDate } } }),
+    prisma.bookingData.count({
+      where: {
+        ...previousBookingWhere,
+        status: { in: ['CONFIRMED', 'COMPLETED'] },
+      },
+    }),
+  ]);
+
+  const conversionRate = searchCount > 0 ? (confirmedBookings / searchCount) * 100 : 0;
+  const previousConversionRate = previousSearchCount > 0 ? (previousConfirmedBookings / previousSearchCount) * 100 : 0;
+
+  const avgBookingValue = totalBookings > 0 ? revenue / totalBookings : 0;
+
+  const evolution = (current: number, previous: number) =>
+    previous > 0 ? Math.round(((current - previous) / previous) * 100) : current > 0 ? 100 : 0;
+
+  return {
+    users: {
+      total: totalUsers,
+      active: activeUsers,
+      inactive: totalUsers - activeUsers,
+      newInPeriod: newUsers,
+      evolution: evolution(newUsers, previousNewUsers),
+    },
+    bookings: {
+      total: totalBookings,
+      byStatus: Object.fromEntries(bookingsByStatus.map(b => [b.status, b._count.id])),
+      evolution: evolution(totalBookings, previousTotalBookings),
+    },
+    revenue: {
+      total: revenue,
+      currency: 'EUR',
+      evolution: evolution(revenue, previousRevenue),
+    },
+    conversionRate: {
+      rate: Math.round(conversionRate * 100) / 100,
+      evolution: Math.round((conversionRate - previousConversionRate) * 100) / 100,
+    },
+    avgBookingValue: {
+      amount: Math.round(avgBookingValue * 100) / 100,
+      currency: 'EUR',
+    },
+  };
+}
+
+export async function getRevenueChart(period: Period) {
+  const { startDate, endDate } = period;
+
+  const result = await prisma.$queryRaw<Array<{ date: Date; revenue: number }>>`
+    SELECT
+      date_trunc('day', "created_at") as date,
+      COALESCE(SUM(amount), 0)::float as revenue
+    FROM payment_transactions
+    WHERE status = 'SUCCEEDED'
+      AND "created_at" >= ${startDate}
+      AND "created_at" <= ${endDate}
+    GROUP BY date_trunc('day', "created_at")
+    ORDER BY date
+  `;
+
+  return result.map(r => ({
+    date: r.date.toISOString().split('T')[0],
+    revenue: r.revenue,
+  }));
+}
+
+export async function getBookingsByDestination(limit: number = 5) {
+  const bookings = await prisma.bookingData.findMany({
+    where: { status: { in: ['CONFIRMED', 'COMPLETED'] } },
+    select: { data: true },
+  });
+
+  const destinationCounts: Record<string, number> = {};
+  for (const booking of bookings) {
+    const data = booking.data as any;
+    const destination = data?.destination || data?.cityCode || data?.items?.[0]?.itemData?.cityCode || 'Unknown';
+    destinationCounts[destination] = (destinationCounts[destination] || 0) + 1;
+  }
+
+  return Object.entries(destinationCounts)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, limit)
+    .map(([destination, count]) => ({ destination, count }));
+}
+
+export async function getRecentTransactions(limit: number = 10) {
+  const transactions = await prisma.paymentTransaction.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
+
+  const userIds = [...new Set(transactions.map(t => t.userId))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+  const userMap = new Map(users.map(u => [u.id, u]));
+
+  return transactions.map(t => {
+    const user = userMap.get(t.userId);
+    return {
+      id: t.id,
+      userEmail: user?.email || 'Unknown',
+      userName: user ? `${user.firstName || ''} ${user.lastName || ''}`.trim() || user.email : 'Unknown',
+      amount: Number(t.amount),
+      currency: t.currency,
+      status: t.status,
+      paymentMethod: t.paymentMethod,
+      bookingReference: t.bookingReference,
+      createdAt: t.createdAt.toISOString(),
+    };
+  });
+}

--- a/user/src/services/AdminDashboardService.ts
+++ b/user/src/services/AdminDashboardService.ts
@@ -158,27 +158,57 @@ export async function getRevenueChart(period: Period) {
   }));
 }
 
-export async function getBookingsByDestination(limit: number = 5) {
+function extractDestination(type: string, data: any): string {
+  if (!data) return 'Inconnu';
+  switch (type) {
+    case 'FLIGHT':
+    case 'TRANSFER':
+      return data.to || data.destination || data.cityCode || 'Inconnu';
+    case 'HOTEL':
+      return data.city || data.destination || data.hotel || data.cityCode || 'Inconnu';
+    case 'ACTIVITY':
+      return data.city || data.destination || data.location || data.activity || 'Inconnu';
+    case 'PACKAGE':
+      return data.destination || data.city || data.cityCode || 'Inconnu';
+    default:
+      return data.destination || data.city || data.cityCode || data.to || 'Inconnu';
+  }
+}
+
+export async function getBookingsByDestination(limit: number = 5, period?: Period) {
+  const where: any = {
+    status: { in: ['CONFIRMED', 'COMPLETED', 'PENDING', 'PENDING_PAYMENT'] },
+  };
+  if (period) {
+    where.createdAt = { gte: period.startDate, lte: period.endDate };
+  }
+
   const bookings = await prisma.bookingData.findMany({
-    where: { status: { in: ['CONFIRMED', 'COMPLETED'] } },
-    select: { data: true },
+    where,
+    select: { type: true, data: true },
   });
 
   const destinationCounts: Record<string, number> = {};
   for (const booking of bookings) {
-    const data = booking.data as any;
-    const destination = data?.destination || data?.cityCode || data?.items?.[0]?.itemData?.cityCode || 'Unknown';
+    const destination = extractDestination(booking.type, booking.data as any);
     destinationCounts[destination] = (destinationCounts[destination] || 0) + 1;
   }
 
   return Object.entries(destinationCounts)
+    .filter(([dest]) => dest !== 'Inconnu')
     .sort(([, a], [, b]) => b - a)
     .slice(0, limit)
     .map(([destination, count]) => ({ destination, count }));
 }
 
-export async function getRecentTransactions(limit: number = 10) {
+export async function getRecentTransactions(limit: number = 10, period?: Period) {
+  const where: any = {};
+  if (period) {
+    where.createdAt = { gte: period.startDate, lte: period.endDate };
+  }
+
   const transactions = await prisma.paymentTransaction.findMany({
+    where,
     orderBy: { createdAt: 'desc' },
     take: limit,
   });

--- a/user/src/services/AdminPaymentService.ts
+++ b/user/src/services/AdminPaymentService.ts
@@ -1,0 +1,113 @@
+import { prisma } from '@dreamscape/db';
+
+interface ListPaymentsParams {
+  page: number;
+  limit: number;
+  search?: string;
+  status?: string;
+  startDate?: string;
+  endDate?: string;
+  minAmount?: number;
+  maxAmount?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function listPayments(params: ListPaymentsParams) {
+  const { page, limit, search, status, startDate, endDate, minAmount, maxAmount, sortBy = 'createdAt', sortOrder = 'desc' } = params;
+  const skip = (page - 1) * limit;
+
+  const where: any = {};
+
+  if (status) where.status = status;
+
+  if (startDate || endDate) {
+    where.createdAt = {};
+    if (startDate) where.createdAt.gte = new Date(startDate);
+    if (endDate) where.createdAt.lte = new Date(endDate);
+  }
+
+  if (minAmount !== undefined || maxAmount !== undefined) {
+    where.amount = {};
+    if (minAmount !== undefined) where.amount.gte = minAmount;
+    if (maxAmount !== undefined) where.amount.lte = maxAmount;
+  }
+
+  if (search) {
+    where.OR = [
+      { bookingReference: { contains: search, mode: 'insensitive' } },
+      { paymentIntentId: { contains: search, mode: 'insensitive' } },
+    ];
+  }
+
+  const [payments, total] = await Promise.all([
+    prisma.paymentTransaction.findMany({
+      where,
+      orderBy: { [sortBy]: sortOrder },
+      skip,
+      take: limit,
+    }),
+    prisma.paymentTransaction.count({ where }),
+  ]);
+
+  // Enrich with user info
+  const userIds = [...new Set(payments.map((p) => p.userId))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  return {
+    payments: payments.map((p) => ({
+      ...p,
+      amount: Number(p.amount),
+      user: userMap.get(p.userId) ?? null,
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
+}
+
+export async function getPaymentById(id: string) {
+  const payment = await prisma.paymentTransaction.findUnique({ where: { id } });
+  if (!payment) throw new Error('Payment not found');
+
+  const user = await prisma.user.findUnique({
+    where: { id: payment.userId },
+    select: { id: true, email: true, firstName: true, lastName: true, username: true },
+  });
+
+  const booking = await prisma.bookingData.findUnique({
+    where: { id: payment.bookingId },
+    select: { id: true, reference: true, type: true, status: true, totalAmount: true, currency: true, createdAt: true },
+  });
+
+  return {
+    ...payment,
+    amount: Number(payment.amount),
+    user,
+    booking: booking ? { ...booking, totalAmount: Number(booking.totalAmount) } : null,
+  };
+}
+
+export async function updatePaymentStatus(id: string, status: string) {
+  const existing = await prisma.paymentTransaction.findUnique({ where: { id } });
+  if (!existing) throw new Error('Payment not found');
+
+  const validStatuses = ['PENDING', 'SUCCEEDED', 'FAILED', 'REFUNDED'];
+  if (!validStatuses.includes(status)) throw new Error('Invalid status');
+
+  const updateData: any = { status };
+  const now = new Date();
+  if (status === 'SUCCEEDED' && !existing.confirmedAt) updateData.confirmedAt = now;
+  if (status === 'FAILED' && !existing.failedAt) updateData.failedAt = now;
+  if (status === 'REFUNDED' && !existing.refundedAt) updateData.refundedAt = now;
+
+  const payment = await prisma.paymentTransaction.update({ where: { id }, data: updateData });
+  return { ...payment, amount: Number(payment.amount) };
+}

--- a/user/src/services/AdminUserService.ts
+++ b/user/src/services/AdminUserService.ts
@@ -1,0 +1,149 @@
+import { prisma } from '@dreamscape/db';
+
+interface ListUsersParams {
+  page: number;
+  limit: number;
+  search?: string;
+  role?: string;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function listUsers(params: ListUsersParams) {
+  const { page, limit, search, role, sortBy = 'createdAt', sortOrder = 'desc' } = params;
+  const skip = (page - 1) * limit;
+
+  const where: any = {};
+
+  if (search) {
+    where.OR = [
+      { email: { contains: search, mode: 'insensitive' } },
+      { firstName: { contains: search, mode: 'insensitive' } },
+      { lastName: { contains: search, mode: 'insensitive' } },
+      { username: { contains: search, mode: 'insensitive' } },
+    ];
+  }
+
+  if (role) {
+    where.role = role;
+  }
+
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        firstName: true,
+        lastName: true,
+        role: true,
+        isVerified: true,
+        userCategory: true,
+        createdAt: true,
+        updatedAt: true,
+        onboardingCompleted: true,
+        _count: {
+          select: {
+            searches: true,
+            favorites: true,
+            notifications: true,
+          },
+        },
+      },
+      orderBy: { [sortBy]: sortOrder },
+      skip,
+      take: limit,
+    }),
+    prisma.user.count({ where }),
+  ]);
+
+  return {
+    users,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
+}
+
+export async function getUserById(id: string) {
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      firstName: true,
+      lastName: true,
+      phoneNumber: true,
+      dateOfBirth: true,
+      nationality: true,
+      role: true,
+      userCategory: true,
+      isVerified: true,
+      onboardingCompleted: true,
+      onboardingCompletedAt: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: {
+        select: {
+          searches: true,
+          favorites: true,
+          history: true,
+          notifications: true,
+        },
+      },
+    },
+  });
+
+  if (!user) throw new Error('User not found');
+  return user;
+}
+
+interface UpdateUserData {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  role?: string;
+  isVerified?: boolean;
+  userCategory?: string;
+}
+
+export async function updateUser(id: string, data: UpdateUserData) {
+  const existing = await prisma.user.findUnique({ where: { id } });
+  if (!existing) throw new Error('User not found');
+
+  if (data.email && data.email !== existing.email) {
+    const emailTaken = await prisma.user.findUnique({ where: { email: data.email } });
+    if (emailTaken) throw new Error('Email already in use');
+  }
+
+  const user = await prisma.user.update({
+    where: { id },
+    data: data as any,
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      firstName: true,
+      lastName: true,
+      role: true,
+      isVerified: true,
+      userCategory: true,
+      updatedAt: true,
+    },
+  });
+
+  return user;
+}
+
+export async function deleteUser(id: string) {
+  const existing = await prisma.user.findUnique({ where: { id } });
+  if (!existing) throw new Error('User not found');
+
+  await prisma.user.delete({ where: { id } });
+  return { id };
+}


### PR DESCRIPTION
## Summary
- Add `requireAdmin` middleware (403 if user role !== ADMIN)
- Extend `authenticateToken` to include user role in request
- Create `AdminDashboardService` with Prisma aggregation queries (stats, revenue chart, bookings by destination, recent transactions) with period comparison (evolution %)
- Add controller + routes mounted on `/api/v1/admin/dashboard/*`

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/admin/dashboard/stats` | KPIs: users, bookings, revenue, conversion rate |
| GET | `/api/v1/admin/dashboard/revenue-chart` | Revenue per day (time series) |
| GET | `/api/v1/admin/dashboard/bookings-by-destination` | Top N destinations |
| GET | `/api/v1/admin/dashboard/recent-transactions` | Latest payment transactions |

## Test plan
- [ ] Creer/mettre a jour un user avec `role: ADMIN` en base
- [ ] Verifier que les 4 endpoints retournent 200 avec un token admin
- [ ] Verifier qu'un user `role: USER` recoit 403
- [ ] Tester les differentes periodes (24h, 7d, 30d, custom)
