### PR TITLE
feat(admin): US-ADMIN-004 — backend bookings + SendGrid email service

### DIFF
--- a/user/package.json
+++ b/user/package.json
@@ -23,6 +23,7 @@
     "@dreamscape/db": "file:../db",
     "@dreamscape/kafka": "file:../shared/kafka",
     "@prisma/client": "^5.7.1",
+    "@sendgrid/mail": "^8.1.6",
     "axios": "^1.6.2",
     "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",

--- a/user/src/controllers/adminBookingController.ts
+++ b/user/src/controllers/adminBookingController.ts
@@ -13,17 +13,20 @@ const sendSuccess = (res: Response, data: any): void => {
 export const listBookings = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const page = parseInt(req.query.page as string) || 1;
-    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
     const search = req.query.search as string | undefined;
     const status = req.query.status as string | undefined;
     const type = req.query.type as string | undefined;
     const startDate = req.query.startDate as string | undefined;
     const endDate = req.query.endDate as string | undefined;
-    const sortBy = req.query.sortBy as string || 'createdAt';
+    const sortBy = (req.query.sortBy as string) || 'createdAt';
     const sortOrder = (req.query.sortOrder as string) === 'asc' ? 'asc' : 'desc';
+    const minAmount = req.query.minAmount ? parseFloat(req.query.minAmount as string) : undefined;
+    const maxAmount = req.query.maxAmount ? parseFloat(req.query.maxAmount as string) : undefined;
+    const destination = req.query.destination as string | undefined;
 
     const result = await AdminBookingService.listBookings({
-      page, limit, search, status, type, startDate, endDate, sortBy, sortOrder,
+      page, limit, search, status, type, startDate, endDate, sortBy, sortOrder, minAmount, maxAmount, destination,
     });
     sendSuccess(res, result);
   } catch (error: any) {
@@ -37,10 +40,7 @@ export const getBooking = async (req: AuthRequest, res: Response): Promise<void>
     const booking = await AdminBookingService.getBookingById(req.params.id);
     sendSuccess(res, booking);
   } catch (error: any) {
-    if (error.message === 'Booking not found') {
-      sendError(res, 404, error.message);
-      return;
-    }
+    if (error.message === 'Booking not found') { sendError(res, 404, error.message); return; }
     console.error('Error fetching booking:', error);
     sendError(res, 500, error.message || 'Failed to fetch booking');
   }
@@ -49,21 +49,12 @@ export const getBooking = async (req: AuthRequest, res: Response): Promise<void>
 export const updateBookingStatus = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const { status } = req.body;
-    if (!status) {
-      sendError(res, 400, 'Status is required');
-      return;
-    }
+    if (!status) { sendError(res, 400, 'Status is required'); return; }
     const booking = await AdminBookingService.updateBookingStatus(req.params.id, status);
     sendSuccess(res, booking);
   } catch (error: any) {
-    if (error.message === 'Booking not found') {
-      sendError(res, 404, error.message);
-      return;
-    }
-    if (error.message === 'Invalid status') {
-      sendError(res, 400, error.message);
-      return;
-    }
+    if (error.message === 'Booking not found') { sendError(res, 404, error.message); return; }
+    if (error.message === 'Invalid status') { sendError(res, 400, error.message); return; }
     console.error('Error updating booking status:', error);
     sendError(res, 500, error.message || 'Failed to update booking status');
   }
@@ -72,22 +63,76 @@ export const updateBookingStatus = async (req: AuthRequest, res: Response): Prom
 export const bulkUpdateBookingStatus = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const { ids, status } = req.body;
-    if (!ids || !Array.isArray(ids) || ids.length === 0) {
-      sendError(res, 400, 'ids array is required');
-      return;
-    }
-    if (!status) {
-      sendError(res, 400, 'Status is required');
-      return;
-    }
+    if (!ids || !Array.isArray(ids) || ids.length === 0) { sendError(res, 400, 'ids array is required'); return; }
+    if (!status) { sendError(res, 400, 'Status is required'); return; }
     const result = await AdminBookingService.bulkUpdateBookingStatus(ids, status);
     sendSuccess(res, result);
   } catch (error: any) {
-    if (error.message === 'Invalid status') {
-      sendError(res, 400, error.message);
-      return;
-    }
+    if (error.message === 'Invalid status') { sendError(res, 400, error.message); return; }
     console.error('Error bulk updating booking statuses:', error);
     sendError(res, 500, error.message || 'Failed to bulk update');
+  }
+};
+
+export const cancelBooking = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { refund = false, reason = '' } = req.body;
+    const booking = await AdminBookingService.cancelBooking(req.params.id, Boolean(refund), String(reason));
+    sendSuccess(res, booking);
+  } catch (error: any) {
+    if (error.message === 'Booking not found') { sendError(res, 404, error.message); return; }
+    if (error.message === 'Booking already cancelled' || error.message === 'Cannot cancel a completed booking') {
+      sendError(res, 409, error.message); return;
+    }
+    console.error('Error cancelling booking:', error);
+    sendError(res, 500, error.message || 'Failed to cancel booking');
+  }
+};
+
+export const modifyBooking = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { totalAmount, notes, data } = req.body;
+    const booking = await AdminBookingService.modifyBooking(req.params.id, { totalAmount, notes, data });
+    sendSuccess(res, booking);
+  } catch (error: any) {
+    if (error.message === 'Booking not found') { sendError(res, 404, error.message); return; }
+    console.error('Error modifying booking:', error);
+    sendError(res, 500, error.message || 'Failed to modify booking');
+  }
+};
+
+export const resendEmail = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const result = await AdminBookingService.resendConfirmationEmail(req.params.id);
+    sendSuccess(res, result);
+  } catch (error: any) {
+    if (error.message === 'Booking not found') { sendError(res, 404, error.message); return; }
+    if (error.message === 'SENDGRID_NOT_CONFIGURED') {
+      sendError(res, 503, 'Envoi d\'email non disponible : SENDGRID_API_KEY manquante dans la configuration du serveur.');
+      return;
+    }
+    console.error('Error resending email:', error);
+    sendError(res, 500, error.message || 'Failed to resend email');
+  }
+};
+
+export const exportBookings = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const search = req.query.search as string | undefined;
+    const status = req.query.status as string | undefined;
+    const type = req.query.type as string | undefined;
+    const startDate = req.query.startDate as string | undefined;
+    const endDate = req.query.endDate as string | undefined;
+    const minAmount = req.query.minAmount ? parseFloat(req.query.minAmount as string) : undefined;
+    const maxAmount = req.query.maxAmount ? parseFloat(req.query.maxAmount as string) : undefined;
+    const destination = req.query.destination as string | undefined;
+
+    const csv = await AdminBookingService.exportBookings({ search, status, type, startDate, endDate, minAmount, maxAmount, destination });
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="bookings-export.csv"');
+    res.send(csv);
+  } catch (error: any) {
+    console.error('Error exporting bookings:', error);
+    sendError(res, 500, error.message || 'Failed to export bookings');
   }
 };

--- a/user/src/routes/admin.ts
+++ b/user/src/routes/admin.ts
@@ -28,8 +28,12 @@ router.delete('/users/:id', userCtrl.deleteUser);
 
 // Bookings
 router.get('/bookings', bookingCtrl.listBookings);
+router.get('/bookings/export', bookingCtrl.exportBookings);   // BEFORE /:id
 router.get('/bookings/:id', bookingCtrl.getBooking);
 router.put('/bookings/:id/status', bookingCtrl.updateBookingStatus);
+router.put('/bookings/:id/cancel', bookingCtrl.cancelBooking);
+router.put('/bookings/:id/modify', bookingCtrl.modifyBooking);
+router.post('/bookings/:id/resend-email', bookingCtrl.resendEmail);
 router.put('/bookings/bulk/status', bookingCtrl.bulkUpdateBookingStatus);
 
 // Payments

--- a/user/src/services/AdminBookingService.ts
+++ b/user/src/services/AdminBookingService.ts
@@ -1,4 +1,9 @@
+import axios from 'axios';
 import { prisma } from '@dreamscape/db';
+import notificationService from './NotificationService';
+import { sendBookingConfirmationEmail, isSendGridConfigured } from './EmailService';
+
+const PAYMENT_SERVICE_URL = process.env.PAYMENT_SERVICE_URL || 'http://localhost:3004';
 
 interface ListBookingsParams {
   page: number;
@@ -10,6 +15,21 @@ interface ListBookingsParams {
   endDate?: string;
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
+  minAmount?: number;
+  maxAmount?: number;
+  destination?: string;
+}
+
+function extractDestination(type: string, data: any): string | null {
+  if (!data) return null;
+  switch (type) {
+    case 'FLIGHT': return data.to || data.destination || null;
+    case 'HOTEL': return data.hotel || data.city || data.destination || null;
+    case 'PACKAGE': return data.destination || null;
+    case 'ACTIVITY': return data.location || data.city || data.destination || null;
+    case 'TRANSFER': return data.to || data.destination || null;
+    default: return data.destination || null;
+  }
 }
 
 async function enrichWithUsers<T extends { userId: string }>(items: T[]) {
@@ -22,10 +42,8 @@ async function enrichWithUsers<T extends { userId: string }>(items: T[]) {
   return items.map((item) => ({ ...item, user: userMap.get(item.userId) ?? null }));
 }
 
-export async function listBookings(params: ListBookingsParams) {
-  const { page, limit, search, status, type, startDate, endDate, sortBy = 'createdAt', sortOrder = 'desc' } = params;
-  const skip = (page - 1) * limit;
-
+function buildWhere(params: Omit<ListBookingsParams, 'page' | 'limit' | 'sortBy' | 'sortOrder' | 'destination'>) {
+  const { search, status, type, startDate, endDate, minAmount, maxAmount } = params;
   const where: any = {};
 
   if (status) where.status = status;
@@ -34,36 +52,71 @@ export async function listBookings(params: ListBookingsParams) {
   if (startDate || endDate) {
     where.createdAt = {};
     if (startDate) where.createdAt.gte = new Date(startDate);
-    if (endDate) where.createdAt.lte = new Date(endDate);
+    if (endDate) where.createdAt.lte = new Date(endDate + 'T23:59:59');
   }
 
-  // Search by reference first, then filter by user if needed
-  if (search) {
-    const matchingUsers = await prisma.user.findMany({
-      where: {
-        OR: [
-          { email: { contains: search, mode: 'insensitive' } },
-          { firstName: { contains: search, mode: 'insensitive' } },
-          { lastName: { contains: search, mode: 'insensitive' } },
-        ],
-      },
-      select: { id: true },
-    });
-    const userIds = matchingUsers.map((u) => u.id);
-
-    where.OR = [
-      { reference: { contains: search, mode: 'insensitive' } },
-      ...(userIds.length > 0 ? [{ userId: { in: userIds } }] : []),
-    ];
+  if (minAmount !== undefined || maxAmount !== undefined) {
+    where.totalAmount = {};
+    if (minAmount !== undefined) where.totalAmount.gte = minAmount;
+    if (maxAmount !== undefined) where.totalAmount.lte = maxAmount;
   }
 
-  const [bookings, total] = await Promise.all([
-    prisma.bookingData.findMany({
+  return { where, searchTerm: search };
+}
+
+async function applySearchToWhere(where: any, search?: string) {
+  if (!search) return where;
+  const matchingUsers = await prisma.user.findMany({
+    where: {
+      OR: [
+        { email: { contains: search, mode: 'insensitive' } },
+        { firstName: { contains: search, mode: 'insensitive' } },
+        { lastName: { contains: search, mode: 'insensitive' } },
+      ],
+    },
+    select: { id: true },
+  });
+  const userIds = matchingUsers.map((u) => u.id);
+  where.OR = [
+    { reference: { contains: search, mode: 'insensitive' } },
+    ...(userIds.length > 0 ? [{ userId: { in: userIds } }] : []),
+  ];
+  return where;
+}
+
+export async function listBookings(params: ListBookingsParams) {
+  const { page, limit, sortBy = 'createdAt', sortOrder = 'desc', destination } = params;
+
+  const { where, searchTerm } = buildWhere(params);
+  await applySearchToWhere(where, searchTerm);
+
+  // Destination requires in-memory filter (JSON field varies by type)
+  if (destination) {
+    const allBookings = await prisma.bookingData.findMany({
       where,
       orderBy: { [sortBy]: sortOrder },
-      skip,
-      take: limit,
-    }),
+    });
+    const enriched = await enrichWithUsers(
+      allBookings.map((b) => ({ ...b, totalAmount: Number(b.totalAmount) }))
+    );
+    const withDest = enriched.map((b) => ({
+      ...b,
+      destination: extractDestination(b.type, b.data as any),
+    }));
+    const filtered = withDest.filter((b) =>
+      b.destination?.toLowerCase().includes(destination.toLowerCase())
+    );
+    const total = filtered.length;
+    const skip = (page - 1) * limit;
+    return {
+      bookings: filtered.slice(skip, skip + limit),
+      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    };
+  }
+
+  const skip = (page - 1) * limit;
+  const [bookings, total] = await Promise.all([
+    prisma.bookingData.findMany({ where, orderBy: { [sortBy]: sortOrder }, skip, take: limit }),
     prisma.bookingData.count({ where }),
   ]);
 
@@ -72,13 +125,11 @@ export async function listBookings(params: ListBookingsParams) {
   );
 
   return {
-    bookings: enriched,
-    pagination: {
-      page,
-      limit,
-      total,
-      totalPages: Math.ceil(total / limit),
-    },
+    bookings: enriched.map((b) => ({
+      ...b,
+      destination: extractDestination(b.type, b.data as any),
+    })),
+    pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
   };
 }
 
@@ -102,6 +153,7 @@ export async function getBookingById(id: string) {
   return {
     ...booking,
     totalAmount: Number(booking.totalAmount),
+    destination: extractDestination(booking.type, booking.data as any),
     user,
     payment,
   };
@@ -125,7 +177,12 @@ export async function updateBookingStatus(id: string, status: string) {
     select: { id: true, email: true, firstName: true, lastName: true },
   });
 
-  return { ...booking, totalAmount: Number(booking.totalAmount), user };
+  return {
+    ...booking,
+    totalAmount: Number(booking.totalAmount),
+    destination: extractDestination(booking.type, booking.data as any),
+    user,
+  };
 }
 
 export async function bulkUpdateBookingStatus(ids: string[], status: string) {
@@ -135,10 +192,154 @@ export async function bulkUpdateBookingStatus(ids: string[], status: string) {
   const updateData: any = { status };
   if (status === 'CONFIRMED') updateData.confirmedAt = new Date();
 
-  await prisma.bookingData.updateMany({
-    where: { id: { in: ids } },
-    data: updateData,
+  await prisma.bookingData.updateMany({ where: { id: { in: ids } }, data: updateData });
+  return { updated: ids.length };
+}
+
+export async function cancelBooking(id: string, refund: boolean, reason: string) {
+  const booking = await prisma.bookingData.findUnique({ where: { id } });
+  if (!booking) throw new Error('Booking not found');
+  if (booking.status === 'CANCELLED') throw new Error('Booking already cancelled');
+  if (booking.status === 'COMPLETED') throw new Error('Cannot cancel a completed booking');
+
+  const updated = await prisma.bookingData.update({
+    where: { id },
+    data: { status: 'CANCELLED' },
   });
 
-  return { updated: ids.length };
+  if (refund && booking.paymentIntentId) {
+    try {
+      await axios.post(`${PAYMENT_SERVICE_URL}/api/v1/payment/refund`, {
+        paymentIntentId: booking.paymentIntentId,
+        bookingId: id,
+        userId: booking.userId,
+        reason: reason || 'Admin cancellation',
+      });
+    } catch (err: any) {
+      console.error('[AdminBookingService] Refund call failed:', err?.message);
+      // Booking is already cancelled — refund failure is non-blocking
+    }
+  }
+
+  try {
+    await notificationService.createNotification(booking.userId, {
+      type: 'BOOKING_CANCELLED',
+      title: 'Réservation annulée',
+      message: reason || 'Votre réservation a été annulée par l\'administration.',
+      metadata: { bookingId: id, reference: booking.reference },
+    });
+  } catch (err) {
+    console.error('[AdminBookingService] Notification failed:', err);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: booking.userId },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+
+  return {
+    ...updated,
+    totalAmount: Number(updated.totalAmount),
+    destination: extractDestination(updated.type, updated.data as any),
+    user,
+  };
+}
+
+export async function modifyBooking(
+  id: string,
+  updates: { totalAmount?: number; notes?: string; data?: Record<string, any> }
+) {
+  const booking = await prisma.bookingData.findUnique({ where: { id } });
+  if (!booking) throw new Error('Booking not found');
+
+  const updateData: any = {};
+  if (updates.totalAmount !== undefined) updateData.totalAmount = updates.totalAmount;
+  if (updates.data || updates.notes !== undefined) {
+    const existingData = (booking.data as Record<string, any>) || {};
+    updateData.data = {
+      ...existingData,
+      ...(updates.data || {}),
+      ...(updates.notes !== undefined ? { adminNotes: updates.notes } : {}),
+    };
+  }
+
+  const updated = await prisma.bookingData.update({ where: { id }, data: updateData });
+  const user = await prisma.user.findUnique({
+    where: { id: booking.userId },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+
+  return {
+    ...updated,
+    totalAmount: Number(updated.totalAmount),
+    destination: extractDestination(updated.type, updated.data as any),
+    user,
+  };
+}
+
+export async function resendConfirmationEmail(id: string) {
+  if (!isSendGridConfigured()) {
+    throw new Error('SENDGRID_NOT_CONFIGURED');
+  }
+
+  const booking = await prisma.bookingData.findUnique({ where: { id } });
+  if (!booking) throw new Error('Booking not found');
+
+  const user = await prisma.user.findUnique({
+    where: { id: booking.userId },
+    select: { email: true, firstName: true, lastName: true },
+  });
+  if (!user) throw new Error('User not found');
+
+  const userName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.email;
+  const destination = extractDestination(booking.type, booking.data as any);
+
+  await sendBookingConfirmationEmail({
+    to: user.email,
+    userName,
+    reference: booking.reference,
+    type: booking.type,
+    destination,
+    totalAmount: Number(booking.totalAmount),
+    currency: booking.currency,
+  });
+
+  return { success: true };
+}
+
+export async function exportBookings(filters: Omit<ListBookingsParams, 'page' | 'limit' | 'sortBy' | 'sortOrder'>) {
+  const { where, searchTerm } = buildWhere(filters);
+  await applySearchToWhere(where, searchTerm);
+
+  const bookings = await prisma.bookingData.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: 10000,
+  });
+
+  const enriched = await enrichWithUsers(
+    bookings.map((b) => ({ ...b, totalAmount: Number(b.totalAmount) }))
+  );
+
+  const headers = ['id', 'reference', 'type', 'status', 'destination', 'userId', 'userEmail', 'totalAmount', 'currency', 'confirmedAt', 'createdAt'];
+  const escape = (v: any) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+
+  const rows = enriched.map((b) => {
+    const dest = extractDestination(b.type, b.data as any);
+    return [
+      b.id,
+      b.reference,
+      b.type,
+      b.status,
+      dest || '',
+      b.userId,
+      b.user?.email || '',
+      b.totalAmount,
+      b.currency,
+      (b as any).confirmedAt?.toISOString() || '',
+      b.createdAt.toISOString(),
+    ].map(escape).join(',');
+  });
+
+  return [headers.join(','), ...rows].join('\n');
 }

--- a/user/src/services/EmailService.ts
+++ b/user/src/services/EmailService.ts
@@ -1,0 +1,72 @@
+import sgMail from '@sendgrid/mail';
+
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || 'noreply@dreamscape.app';
+const SENDGRID_FROM_NAME = process.env.SENDGRID_FROM_NAME || 'Dreamscape';
+
+export function isSendGridConfigured(): boolean {
+  return !!SENDGRID_API_KEY && SENDGRID_API_KEY !== 'your-sendgrid-api-key-here';
+}
+
+if (SENDGRID_API_KEY && isSendGridConfigured()) {
+  sgMail.setApiKey(SENDGRID_API_KEY);
+}
+
+interface SendEmailParams {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+}
+
+export async function sendEmail(params: SendEmailParams): Promise<void> {
+  if (!isSendGridConfigured()) {
+    throw new Error('SENDGRID_NOT_CONFIGURED');
+  }
+
+  await sgMail.send({
+    to: params.to,
+    from: { email: SENDGRID_FROM_EMAIL, name: SENDGRID_FROM_NAME },
+    subject: params.subject,
+    text: params.text,
+    html: params.html || params.text,
+  });
+}
+
+export async function sendBookingConfirmationEmail(params: {
+  to: string;
+  userName: string;
+  reference: string;
+  type: string;
+  destination: string | null;
+  totalAmount: number;
+  currency: string;
+}): Promise<void> {
+  const { to, userName, reference, type, destination, totalAmount, currency } = params;
+
+  const formattedAmount = totalAmount.toLocaleString('fr-FR', { style: 'currency', currency });
+  const destLine = destination ? `<p><strong>Destination :</strong> ${destination}</p>` : '';
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2 style="color: #f97316;">Confirmation de réservation — Dreamscape</h2>
+      <p>Bonjour ${userName},</p>
+      <p>Votre réservation a bien été confirmée.</p>
+      <div style="background: #f9fafb; border-radius: 8px; padding: 16px; margin: 16px 0;">
+        <p><strong>Référence :</strong> ${reference}</p>
+        <p><strong>Type :</strong> ${type}</p>
+        ${destLine}
+        <p><strong>Montant :</strong> ${formattedAmount}</p>
+      </div>
+      <p>Pour toute question, contactez notre support.</p>
+      <p>L'équipe Dreamscape</p>
+    </div>
+  `;
+
+  await sendEmail({
+    to,
+    subject: `Confirmation de réservation ${reference} — Dreamscape`,
+    text: `Bonjour ${userName}, votre réservation ${reference} est confirmée. Montant : ${formattedAmount}.`,
+    html,
+  });
+}


### PR DESCRIPTION
## Summary

- `AdminBookingService` : `cancelBooking` (appel HTTP au payment service si refund=true), `modifyBooking`, `resendConfirmationEmail` (SendGrid direct, sans Kafka), `exportBookings` (CSV)
- `listBookings` étendu : filtres `minAmount`, `maxAmount`, `destination` (post-filter in-memory), champ `destination` extrait du JSON `data` selon le type de booking
- `adminBookingController` : 4 nouveaux handlers + message 503 explicite si SendGrid non configuré
- `routes/admin` : `GET /bookings/export` déclaré avant `/:id`, nouvelles routes cancel/modify/resend-email
- `EmailService` : wrapper SendGrid avec guard `isSendGridConfigured()` — aucun envoi silencieux
- Variables à configurer : `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `SENDGRID_FROM_NAME` dans `user/.env`

## Tickets
DR-471 · DR-472 · DR-473 · DR-474

## Test plan
- [ ] `PUT /v1/admin/bookings/:id/cancel` avec `refund: true` → appel payment service
- [ ] `PUT /v1/admin/bookings/:id/cancel` avec `refund: false` → status CANCELLED sans appel Stripe
- [ ] `POST /v1/admin/bookings/:id/resend-email` sans SENDGRID_API_KEY → 503 avec message explicite
- [ ] `GET /v1/admin/bookings/export` → CSV téléchargeable
- [ ] Filtre `destination` fonctionne sur les bookings FLIGHT et HOTEL