### PR TITLE
docs: update root README and create READMEs for all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,212 @@
-🔧 DreamScape Backend Services
+# DreamScape Backend Services
 
-> **Microservices Backend Platform** - Tous les services backend DreamScape
+> **Microservices Backend Platform** — Tous les services backend DreamScape
 
-## 📁 Structure des Services
+## Structure des services
 
-- **auth/** - Service d'authentification & autorisation (Port 3001)
-- **user/** - Service gestion utilisateurs & profils (Port 3002)
-- **voyage/** - Service voyage, réservation & API Amadeus (Port 3003)
-- **payment/** - Service paiement & transactions (Port 3004)
-- **ai/** - Service IA & recommandations personnalisées (Port 3005)
-- **panorama/** - Service panorama/VR immersif (Port 3006)
+| Dossier | Port | Description |
+|---------|------|-------------|
+| `auth/` | 3001 | Authentification & gestion des JWT |
+| `user/` | 3002 | Profils, préférences, GDPR, notifications |
+| `voyage/` | 3003 | Recherche & réservation voyage (Amadeus) |
+| `payment/` | 3004 | Paiements & webhooks (Stripe) |
+| `ai/` | 3005 | Recommandations IA personnalisées |
+| `db/` | — | Schéma Prisma partagé (PostgreSQL) |
+| `shared/` | — | Package `@dreamscape/kafka` (Kafka utilities) |
 
-## 🛠️ Stack Technique
+## Stack technique
 
-### **Backend Core**
-- **Node.js 18+** - Environnement d'exécution
-- **Express** - Framework web
-- **TypeScript** - Type safety
-- **Prisma** - ORM base de données
+### Backend Core
+- **Node.js 18+** — Environnement d'exécution
+- **Express 4** — Framework web
+- **TypeScript** (strict, ES2022, commonjs) — Type safety
+- **Prisma** — ORM, client partagé via `@dreamscape/db`
 
-### **Bases de Données**
-- **PostgreSQL** - Données principales
-- **MongoDB** - Documents & analytics
-- **Redis** - Cache & sessions
+### Bases de données
+- **PostgreSQL** — Données principales pour tous les services (schéma unifié 800+ lignes)
+- **Redis** — Cache, sessions, rate limiting (dégradation gracieuse si indisponible)
 
-### **External APIs**
-- **Amadeus SDK** - API voyage & réservations
-- **OpenAI API** - Intelligence artificielle
-- **Stripe API** - Paiements sécurisés
+### APIs externes
+- **Amadeus SDK** — Recherche vols, hôtels, activités
+- **OpenAI API** — Recommandations IA
+- **Stripe API** — Paiements et webhooks
 
-### **Architecture**
-- **JWT Authentication** - Sécurité inter-services
-- **Circuit Breaker** - Résilience API externes
-- **Rate Limiting** - Protection contre les abus
-- **Event-Driven** - Communication asynchrone
+### Communication
+- **HTTP/REST** — Synchrone inter-services via axios + JWT
+- **Kafka (kafkajs)** — Asynchrone event-driven, topics `dreamscape.<domain>.<event>`
+- **Socket.io** — Notifications temps réel (User Service)
 
-## 🚀 Quick Start
-
-### Développement Local
-```bash
-# Installation des dépendances
-npm install
-
-# Variables d'environnement
-cp .env.example .env
-
-# Base de données
-npm run migrate
-npm run seed
-
-# Démarrer tous les services
-docker-compose up -d
-
-# Ou service individuel
-cd auth && npm install && npm run dev
-```
-
-### Ports par Défaut
-| Service  | Port | Description                    |
-|----------|------|--------------------------------|
-| Auth     | 3001 | Authentification & JWT         |
-| User     | 3002 | Profils & préférences         |
-| Voyage   | 3003 | Recherches & réservations     |
-| Payment  | 3004 | Paiements & transactions      |
-| AI       | 3005 | Recommandations IA            |
-| Panorama | 3006 | Expériences VR                |
-
-## 📊 Communication Inter-Services
-
-```
-┌─────────────────┐    ┌─────────────────┐
-│   API Gateway   │────│   Auth Service  │
-│     (3000)      │    │     (3001)      │
-└─────────────────┘    └─────────────────┘
-         │                       │
-         ├───────┬───────┬───────┼───────┬────────┐
-         │       │       │       │       │        │
-    ┌─────────┐ │  ┌─────────┐ │  ┌─────────┐   │
-    │  User   │ │  │ Voyage  │ │  │   AI    │   │
-    │ (3002)  │ │  │ (3003)  │ │  │ (3005)  │   │
-    └─────────┘ │  └─────────┘ │  └─────────┘   │
-         │       │       │       │       │        │
-    ┌─────────┐ │  ┌─────────────────┐   │   ┌─────────┐
-    │Payment  │ │  │    Panorama     │   │   │  Redis  │
-    │ (3004)  │ │  │     (3006)      │   │   │ Cache   │
-    └─────────┘ │  └─────────────────┘   │   └─────────┘
-                │                        │
-           ┌─────────────┐         ┌─────────────┐
-           │ PostgreSQL  │         │  MongoDB    │
-           │  Primary    │         │ Analytics   │
-           └─────────────┘         └─────────────┘
-```
-
-## 🧪 Tests & Qualité
+## Quick Start
 
 ```bash
-# Tests unitaires
-npm run test
+# Démarrer l'infrastructure (depuis la racine du monorepo)
+make db          # PostgreSQL + Redis
 
-# Tests d'intégration
-npm run test:integration
+# Chaque service individuellement
+cd auth    && npm install && npm run dev    # :3001
+cd user    && npm install && npm run dev    # :3002
+cd voyage  && npm install && npm run dev    # :3003
+cd payment && npm install && npm run dev    # :3004 (nodemon + ts-node)
+cd ai      && npm install && npm run dev    # :3005
 
-# Couverture de code
-npm run test:coverage
-
-# Linting & formatage
-npm run lint
-npm run lint:fix
+# Ou via Docker Compose (depuis dreamscape-infra/)
+docker-compose -f docker/docker-compose.core-pod.yml up -d      # Core Pod
+docker-compose -f docker/docker-compose.business-pod.yml up -d  # Business Pod
 ```
 
-## 🚀 Déploiement
+## Base de données
+
+Tous les services partagent **un seul schéma Prisma** :
 
 ```bash
-# Build production
-npm run build
+# Après toute modification du schéma
+cd db && npm run db:generate   # Régénérer le client Prisma
 
-# Images Docker
-npm run docker:build
-
-# Déploiement K8s
-kubectl apply -f k8s/
-
-# Terraform infrastructure
-cd terraform && terraform apply
+# Chaque service doit aussi régénérer
+cd auth    && npx prisma generate
+cd user    && npx prisma generate
+cd voyage  && npx prisma generate
+cd payment && npx prisma generate
+cd ai      && npx prisma generate
 ```
 
-## 🔐 Sécurité
+```env
+# Pattern DATABASE_URL (tous services)
+DATABASE_URL="postgresql://dreamscape_user:password@localhost:5432/dreamscape"
+```
 
-- **JWT Authentication** avec refresh tokens
-- **RBAC** (Role-Based Access Control)
-- **API Rate Limiting** par service
-- **Input Validation** & sanitisation
-- **HTTPS/TLS** encryption
-- **Secrets Management** via vault
+> Utiliser `npx prisma db push` en développement (évite les conflits shadow DB de `migrate dev`).
 
-## 📈 Monitoring
+## Package partagé Kafka
 
-- **Health Checks** - `/health` sur chaque service
-- **Prometheus Metrics** - Métriques applicatives
-- **Structured Logging** - JSON centralisé
-- **Error Tracking** - Sentry intégration
+```bash
+# Après modification de shared/kafka/src/
+cd shared/kafka && npm run build   # OBLIGATOIRE avant usage dans les services
+```
 
-## 📚 Services Documentation
+Les services consomment `@dreamscape/kafka` via `file:../shared/kafka`.
 
-### Auth Service (3001)
-- JWT token generation & validation
-- User authentication & authorization
-- Role-based access control
-- Password hashing & security
+## Communication inter-services
 
-### User Service (3002)  
-- User profile management
-- Preferences & settings
-- Activity tracking
-- User analytics
+### HTTP (synchrone)
+```
+Gateway (4000) → Auth Service  (3001) /api/v1/auth/*
+               → User Service  (3002) /api/v1/users/*
+               → Voyage Service (3003) /api/v1/voyages/*
+               → Payment Service (3004) /api/v1/payment/*
+               → AI Service    (3005) /api/v1/ai/*
+```
 
-### Voyage Service (3003)
-- Flight search & booking (Amadeus API)
-- Hotel & accommodation booking
-- Activity & experience booking
-- Itinerary management
-- Booking lifecycle management
+### Kafka (asynchrone)
+```
+dreamscape.user.created              — auth → user
+dreamscape.user.preferences.updated — user → ai
+dreamscape.voyage.booking.created   — voyage → payment
+dreamscape.payment.initiated        — payment publishes
+dreamscape.payment.completed        — payment → voyage + user (Saga)
+dreamscape.payment.failed           — payment → voyage + user (Saga)
+```
 
-### Payment Service (3004)
-- Stripe payment integration
-- Transaction management
-- Refund processing
-- Payment analytics
+> Toujours publier avec `.catch()` pour ne pas bloquer les réponses HTTP.
 
-### AI Service (3005)
-- Personalized recommendations
-- User behavior analysis
-- Predictive analytics
-- OpenAI integration
+## Health checks
 
-### Panorama Service (3006)
-- VR/360° experience management
-- Panoramic content delivery
-- Immersive navigation
-- Media processing
+Chaque service expose `/health` :
 
-## 🤝 Contributing
+```json
+{
+  "status": "healthy",
+  "uptime": 123.45,
+  "database": "connected",
+  "cache": "connected",
+  "memory": { "used": "150MB", "total": "512MB" }
+}
+```
 
-1. **Branch Naming**: `feature/service-name/description`
-2. **Commit Convention**: Conventional commits
-3. **Pull Requests**: Must pass all tests
-4. **Code Review**: Required before merge
+```bash
+curl http://localhost:3001/health   # auth
+curl http://localhost:3002/health   # user
+curl http://localhost:3003/health   # voyage
+curl http://localhost:3004/health   # payment
+curl http://localhost:3005/health   # ai
+```
 
-## 📄 License
+## Tests
 
-Propriétaire et confidentiel © DreamScape 2025
+```bash
+# Par service
+cd auth  && npm run test:unit && npm run test:integration
+cd user  && npm run test:unit && npm run test:integration
 
+# Coverage (seuil 70%)
+cd auth && npm run test:coverage
+
+# Depuis dreamscape-tests/
+npm run test:integration:auth
+npm run test:integration:user
+npm run test:integration:kafka
+```
+
+## Variables d'environnement
+
+**Communes à tous les services** :
+```env
+NODE_ENV=development
+PORT=300X
+DATABASE_URL=postgresql://...
+JWT_SECRET=shared-secret
+JWT_EXPIRES_IN=7d
+REDIS_HOST=localhost
+REDIS_PORT=6379
+KAFKA_BROKERS=localhost:9092
+```
+
+**Spécifiques** :
+```env
+# Auth / User
+CORS_ORIGIN=http://localhost:5173
+CLIENT_URL=http://localhost:5173
+
+# Voyage
+AMADEUS_API_KEY=xxx
+AMADEUS_API_SECRET=xxx
+
+# AI
+OPENAI_API_KEY=sk-xxx
+
+# Payment
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+FRONTEND_URL=http://localhost:5173
+```
+
+## Architecture Big Pods (production)
+
+En production, les 5 services sont regroupés en 2 pods via Supervisor + NGINX :
+
+```
+Core Pod      → Auth (3001) + User (3002) + NGINX (:80)
+Business Pod  → Voyage (3003) + AI (3005) + Payment (3004) + NGINX (:80)
+```
+
+Voir `dreamscape-infra/` pour les Dockerfiles et scripts de lancement.
+
+## Sécurité
+
+- JWT avec refresh tokens (accès 7j, refresh configurable)
+- RBAC (Role-Based Access Control) — User Service
+- Rate limiting Redis sur chaque service
+- Helmet (CSP, HSTS, XSS protection)
+- Input validation & sanitisation
+- Audit logging GDPR (User Service)
+
+## Contributing
+
+1. Branch : `feature/<service>/<description>`
+2. Conventional commits (`feat(auth):`, `fix(voyage):`)
+3. Tests requis (coverage > 70%)
+4. PR avec passage de tous les tests CI
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,145 @@
+# Auth Service
+
+> **Service d'authentification** — Gestion des JWT, sessions Redis et autorisations
+
+- **Port** : 3001 (hardcodé dans `src/server.ts`)
+- **Base de route** : `/api/v1/auth`
+- **Health check** : `/health`, `/api/health`
+
+## Responsabilités
+
+- Inscription et connexion des utilisateurs
+- Émission et validation des tokens JWT (access + refresh)
+- Gestion des sessions via Redis
+- Blacklist des tokens révoqués
+- Publication des événements Kafka d'authentification
+
+## Stack
+
+| Technologie | Rôle |
+|-------------|------|
+| Express 4 + TypeScript | Framework HTTP |
+| Prisma + PostgreSQL | Persistance (via `@dreamscape/db`) |
+| Redis | Sessions & blacklist JWT |
+| kafkajs (`@dreamscape/kafka`) | Événements async |
+| bcryptjs | Hachage des mots de passe |
+| jsonwebtoken | Génération/validation JWT |
+| helmet, CORS, cookie-parser | Sécurité |
+
+## Endpoints
+
+### Authentification
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `POST` | `/api/v1/auth/register` | Inscription utilisateur |
+| `POST` | `/api/v1/auth/login` | Connexion, retourne access + refresh tokens |
+| `POST` | `/api/v1/auth/refresh` | Renouvellement du token d'accès |
+| `POST` | `/api/v1/auth/logout` | Révocation du token (blacklist Redis) |
+| `GET`  | `/api/v1/auth/me` | Profil de l'utilisateur connecté |
+| `POST` | `/api/v1/auth/change-password` | Changement de mot de passe |
+
+### Health
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/health` | Statut service, DB, Redis, Kafka |
+
+## Quick Start
+
+```bash
+# Installation
+npm install
+
+# Variables d'environnement
+cp .env.example .env
+
+# Développement (hot reload via tsx)
+npm run dev
+
+# Build TypeScript
+npm run build
+
+# Production
+npm start
+```
+
+## Variables d'environnement
+
+```env
+NODE_ENV=development
+# PORT ignoré — hardcodé 3001 dans server.ts
+DATABASE_URL=postgresql://dreamscape_user:password@localhost:5432/dreamscape
+JWT_SECRET=your-super-secret-jwt-key
+JWT_EXPIRES_IN=7d
+REDIS_HOST=localhost
+REDIS_PORT=6379
+CLIENT_URL=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173
+KAFKA_BROKERS=localhost:9092
+```
+
+## Événements Kafka publiés
+
+| Topic | Déclencheur |
+|-------|-------------|
+| `dreamscape.user.login` | Connexion réussie |
+| `dreamscape.user.logout` | Déconnexion |
+| `dreamscape.user.registered` | Inscription |
+| `dreamscape.user.password.changed` | Changement de mot de passe |
+
+> Tickets Jira : DR-374 (publish), DR-375 (consume)
+
+> Les événements Kafka sont non-bloquants : publiés avec `.catch()` pour ne pas interrompre la réponse HTTP.
+
+## Structure du code
+
+```
+src/
+├── config/
+│   └── redis.ts           # Client Redis
+├── database/
+│   └── DatabaseService.ts # Initialisation Prisma
+├── middleware/
+│   ├── auth.ts            # Validation JWT middleware
+│   └── errorHandler.ts    # Gestion centralisée des erreurs
+├── routes/
+│   ├── auth.ts            # Routes d'authentification
+│   └── health.ts          # Route /health
+├── services/
+│   └── KafkaService.ts    # Publication événements Kafka
+└── server.ts              # Entry point Express
+```
+
+## Tests
+
+```bash
+npm run test              # Tous les tests
+npm run test:unit         # Tests unitaires
+npm run test:integration  # Tests d'intégration (requiert DB)
+npm run test:coverage     # Coverage (seuil 70%)
+npm run lint              # ESLint
+```
+
+Les tests d'intégration utilisent `supertest` avec le header `x-test-rate-limit: true` pour bypasser le rate limiting.
+
+## Dépendances de démarrage
+
+Le service démarre en séquence :
+1. PostgreSQL (obligatoire — arrêt si échec)
+2. Redis (optionnel — dégradation gracieuse)
+3. Kafka (optionnel — dégradation gracieuse)
+
+## Health check response
+
+```json
+{
+  "status": "healthy",
+  "uptime": 123.45,
+  "database": "connected",
+  "cache": "connected",
+  "kafka": "connected"
+}
+```
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*

--- a/payment/README.md
+++ b/payment/README.md
@@ -1,0 +1,146 @@
+# Payment Service
+
+> **Service paiement** — Intégration Stripe, gestion des transactions et webhooks
+
+- **Port** : 3004 (`process.env.PORT || 3004`)
+- **Base de route** : `/api/v1/payment`
+- **Health check** : `/health`
+- **Entry point** : `src/index.ts` (ts-node + nodemon, pas tsx)
+
+## Responsabilités
+
+- Création et gestion des sessions de paiement Stripe
+- Traitement des webhooks Stripe (idempotent via `ProcessedWebhookEvent`)
+- Publication des événements de paiement sur Kafka (Saga Pattern)
+- Historique des transactions
+
+## Stack
+
+| Technologie | Rôle |
+|-------------|------|
+| Express 4 + TypeScript | Framework HTTP |
+| Stripe SDK | Paiements & webhooks |
+| Prisma + PostgreSQL | Persistance (via `@dreamscape/db`) |
+| kafkajs (`@dreamscape/kafka`) | Événements async |
+
+> Différence avec les autres services : utilise **nodemon + ts-node** (pas tsx) pour le développement.
+
+## Endpoints
+
+### Paiement
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `POST` | `/api/v1/payment/create-intent` | Créer un PaymentIntent Stripe |
+| `POST` | `/api/v1/payment/confirm` | Confirmer un paiement |
+| `GET` | `/api/v1/payment/transactions` | Historique des transactions |
+| `GET` | `/api/v1/payment/transactions/:id` | Détail d'une transaction |
+| `POST` | `/api/v1/payment/refund` | Initier un remboursement |
+
+### Webhook
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `POST` | `/api/v1/payment/webhook` | Webhooks Stripe (raw body requis) |
+
+### Health
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/health` | Statut Kafka + Stripe + DB |
+
+## Quick Start
+
+```bash
+npm install
+cp .env.example .env
+npm run dev      # nodemon --watch src --exec ts-node src/index.ts
+```
+
+## Variables d'environnement
+
+```env
+NODE_ENV=development
+PORT=3004
+DATABASE_URL=postgresql://dreamscape_user:password@localhost:5432/dreamscape
+FRONTEND_URL=http://localhost:5173
+KAFKA_BROKERS=localhost:9092
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+```
+
+> Les clés Stripe ne doivent **jamais** être committées dans le repo.
+
+## Webhooks Stripe
+
+Le webhook `/api/v1/payment/webhook` reçoit le **raw body** (middleware `express.raw()` appliqué avant `express.json()`).
+
+Événements traités :
+| Événement Stripe | Action |
+|-----------------|--------|
+| `payment_intent.succeeded` | Publier `dreamscape.payment.completed` |
+| `payment_intent.payment_failed` | Publier `dreamscape.payment.failed` |
+| `charge.refunded` | Publier `dreamscape.payment.refunded` |
+
+Les webhooks sont idempotents grâce au modèle `ProcessedWebhookEvent` (stocke les IDs Stripe traités).
+
+## Événements Kafka publiés
+
+| Topic | Déclencheur |
+|-------|-------------|
+| `dreamscape.payment.initiated` | Création d'un PaymentIntent |
+| `dreamscape.payment.completed` | Paiement confirmé (webhook Stripe) |
+| `dreamscape.payment.failed` | Paiement échoué (webhook Stripe) |
+| `dreamscape.payment.refunded` | Remboursement traité |
+
+> Tickets Jira : DR-378 (publish), DR-379 (consume)
+
+Ces événements déclenchent le **Saga Pattern** :
+- `payment.completed` → Voyage Service confirme la réservation
+- `payment.completed` → User Service envoie une notification in-app
+- `payment.failed` → Voyage Service annule la réservation
+
+## Health check response
+
+```json
+{
+  "status": "ok",
+  "service": "payment-service",
+  "timestamp": "2025-01-01T00:00:00.000Z",
+  "checks": {
+    "kafka": { "healthy": true },
+    "stripe": { "healthy": true },
+    "database": { "healthy": true }
+  }
+}
+```
+
+## Structure du code
+
+```
+src/
+├── middleware/
+│   └── rawBody.ts             # Préserve le raw body pour les webhooks
+├── routes/
+│   └── payment.ts             # Routes paiement & webhook
+├── services/
+│   ├── DatabaseService.ts     # Prisma client
+│   ├── KafkaService.ts        # Publication événements
+│   └── StripeService.ts       # Intégration Stripe
+└── index.ts                   # Entry point (ts-node)
+```
+
+## Dépendances de démarrage
+
+Le service démarre en séquence (les 3 sont obligatoires) :
+1. **PostgreSQL** — obligatoire, arrêt si échec
+2. **Stripe** — obligatoire, arrêt si clés manquantes
+3. **Kafka** — optionnel, dégradation gracieuse
+
+## Tests
+
+```bash
+npm run test
+npm run test:coverage
+```
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,116 @@
+# @dreamscape/kafka — Package partagé Kafka
+
+> **Package utilitaire Kafka** — Abstractions kafkajs partagées entre tous les services DreamScape
+
+## Présentation
+
+Ce package fournit les utilities Kafka communes utilisées par les services backend : configuration des topics, types des événements, helpers de publication et de consommation.
+
+Il est consommé par les services via une dépendance locale :
+```json
+"@dreamscape/kafka": "file:../shared/kafka"
+```
+
+## Structure
+
+```
+shared/kafka/
+├── src/
+│   ├── config.ts        # Définition des topics Kafka
+│   ├── types.ts         # Types TypeScript des événements
+│   ├── producer.ts      # Helper de publication
+│   ├── consumer.ts      # Helper de consommation
+│   └── index.ts         # Exports publics
+├── dist/                # Output compilé (ignoré par git)
+├── package.json
+└── tsconfig.json
+```
+
+## Topics disponibles
+
+Les topics sont définis dans `src/config.ts` :
+
+```
+dreamscape.user.created
+dreamscape.user.updated
+dreamscape.user.login
+dreamscape.user.logout
+dreamscape.user.registered
+dreamscape.user.preferences.updated
+dreamscape.user.onboarding.completed
+
+dreamscape.voyage.booking.created
+dreamscape.voyage.booking.confirmed
+dreamscape.voyage.booking.cancelled
+dreamscape.voyage.search.performed
+dreamscape.voyage.cart.item.added
+
+dreamscape.payment.initiated
+dreamscape.payment.completed
+dreamscape.payment.failed
+dreamscape.payment.refunded
+
+dreamscape.ai.recommendation.generated
+dreamscape.ai.prediction.created
+```
+
+Convention de nommage : `dreamscape.<domain>.<event>[.<sub-event>]`
+
+## Usage dans un service
+
+```typescript
+import { createEvent, KafkaService } from '@dreamscape/kafka'
+
+// Publication d'un événement
+await kafkaService.publishEvent(
+  createEvent('dreamscape.payment.completed', {
+    userId: 'user-123',
+    amount: 299.99,
+    currency: 'EUR',
+    bookingId: 'booking-456'
+  })
+).catch(err => console.error('Kafka publish failed:', err))
+// Non-bloquant : toujours utiliser .catch()
+```
+
+## Rebuild obligatoire
+
+> **IMPORTANT** : Après toute modification des sources (`src/`), le package doit être recompilé avant que les services puissent utiliser les nouvelles définitions.
+
+```bash
+cd shared/kafka
+npm run build    # Compile TypeScript vers dist/
+```
+
+Les services importent le code compilé depuis `dist/`. Sans rebuild, les modifications restent invisibles.
+
+## Ajouter un nouveau topic
+
+1. Ajouter le topic dans `src/config.ts`
+2. Ajouter le type de l'événement dans `src/types.ts`
+3. Rebuilder : `npm run build`
+4. Mettre à jour les services producteurs (publication)
+5. Mettre à jour les services consommateurs (subscription)
+
+## Build & Installation
+
+```bash
+# Depuis le dossier shared/kafka
+npm install
+npm run build
+
+# Depuis un service consommateur (après modification du package)
+cd auth && npm install    # Re-résout le symlink file:
+```
+
+## Variables d'environnement (services)
+
+```env
+KAFKA_BROKERS=localhost:9092
+KAFKA_CLIENT_ID=dreamscape-<service-name>
+KAFKA_GROUP_ID=dreamscape-<service-name>-group
+```
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*

--- a/user/README.md
+++ b/user/README.md
@@ -1,0 +1,180 @@
+# User Service
+
+> **Service utilisateurs** — Profils, préférences, onboarding IA, GDPR, et notifications temps réel
+
+- **Port** : 3002 (`process.env.PORT || 3002`)
+- **Base de route** : `/api/v1/users`
+- **Health check** : `/health`, `/api/health`
+
+## Responsabilités
+
+- Gestion des profils utilisateurs et préférences
+- Onboarding et questionnaire de voyage pour les recommandations IA
+- Historique d'activité et favoris
+- Intégration GDPR (consentements, export, suppression de données)
+- Notifications temps réel via Socket.io
+- Intégration avec le service IA (`/api/v1/ai`)
+- Administration des utilisateurs
+
+## Stack
+
+| Technologie | Rôle |
+|-------------|------|
+| Express 4 + TypeScript | Framework HTTP |
+| Socket.io | Notifications temps réel |
+| Prisma + PostgreSQL | Persistance (via `@dreamscape/db`) |
+| kafkajs (`@dreamscape/kafka`) | Événements async |
+| auditLogger middleware | Journalisation GDPR |
+| express-rate-limit | Rate limiting |
+| multer | Upload d'avatars |
+
+## Endpoints
+
+### Profil
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/users/profile` | Récupérer le profil |
+| `PUT` | `/api/v1/users/profile` | Mettre à jour le profil |
+| `POST` | `/api/v1/users/profile/avatar` | Upload avatar |
+
+### Onboarding
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/users/onboarding` | Récupérer l'onboarding |
+| `POST` | `/api/v1/users/onboarding` | Soumettre l'onboarding voyage |
+| `PUT` | `/api/v1/users/onboarding` | Mettre à jour l'onboarding |
+
+### Favoris & Historique
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/users/favorites` | Liste des favoris |
+| `POST` | `/api/v1/users/favorites` | Ajouter un favori |
+| `DELETE` | `/api/v1/users/favorites/:id` | Supprimer un favori |
+| `GET` | `/api/v1/users/history` | Historique d'activité |
+
+### GDPR
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/users/gdpr/consent` | Récupérer les consentements |
+| `POST` | `/api/v1/users/gdpr/consent` | Enregistrer les consentements |
+| `POST` | `/api/v1/users/gdpr/export` | Demander l'export des données |
+| `DELETE` | `/api/v1/users/gdpr/account` | Demander la suppression du compte |
+
+### Notifications
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/users/notifications` | Lister les notifications |
+| `PUT` | `/api/v1/users/notifications/:id/read` | Marquer comme lu |
+| `GET` | `/api/v1/users/notification-preferences` | Préférences de notification |
+| `PUT` | `/api/v1/users/notification-preferences` | Mettre à jour les préférences |
+
+### Admin
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/admin/users` | Liste des utilisateurs |
+| `GET` | `/api/v1/admin/stats` | Statistiques globales |
+
+### Intégration IA
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/ai/recommendations` | Proxy vers AI Service |
+
+## Quick Start
+
+```bash
+npm install
+cp .env.example .env
+npm run dev      # hot reload via tsx watch
+```
+
+## Variables d'environnement
+
+```env
+NODE_ENV=development
+PORT=3002
+DATABASE_URL=postgresql://dreamscape_user:password@localhost:5432/dreamscape
+JWT_SECRET=your-super-secret-jwt-key
+REDIS_HOST=localhost
+REDIS_PORT=6379
+CLIENT_URL=http://localhost:5173
+CORS_ORIGIN=http://localhost:5173,http://127.0.0.1:5173
+KAFKA_BROKERS=localhost:9092
+AI_SERVICE_URL=http://localhost:3005
+```
+
+## Notifications temps réel (Socket.io)
+
+Le service expose un serveur Socket.io sur le même port HTTP :
+
+```typescript
+// Connexion côté client
+const socket = io('http://localhost:3002', {
+  auth: { token: 'Bearer <access_token>' }
+})
+
+// L'utilisateur rejoint automatiquement la room user:<userId>
+socket.on('notification', (data) => {
+  console.log('Nouvelle notification:', data)
+})
+```
+
+Les notifications sont déclenchées par les événements Kafka :
+- `dreamscape.payment.completed` → notification "Paiement confirmé"
+- `dreamscape.payment.failed` → notification "Paiement échoué"
+
+## Événements Kafka
+
+**Publiés** :
+| Topic | Déclencheur |
+|-------|-------------|
+| `dreamscape.user.created` | Création de profil |
+| `dreamscape.user.updated` | Mise à jour profil |
+| `dreamscape.user.preferences.updated` | Modification préférences |
+| `dreamscape.user.onboarding.completed` | Fin de l'onboarding |
+
+**Consommés** :
+| Topic | Action |
+|-------|--------|
+| `dreamscape.payment.completed` | Créer notification in-app |
+| `dreamscape.payment.failed` | Créer notification in-app |
+
+## Structure du code
+
+```
+src/
+├── config/
+│   └── redis.ts
+├── middleware/
+│   ├── auth.ts
+│   ├── auditLogger.ts       # Journalisation GDPR
+│   ├── errorHandler.ts
+│   └── rateLimiter.ts
+├── routes/
+│   ├── profile.ts
+│   ├── onboarding.ts
+│   ├── favorites.ts
+│   ├── history.ts
+│   ├── gdpr.ts
+│   ├── notificationRoutes.ts
+│   ├── notificationPreferencesRoutes.ts
+│   ├── aiIntegration.ts
+│   ├── admin.ts
+│   └── health.ts
+├── services/
+│   ├── KafkaService.ts
+│   ├── NotificationService.ts
+│   └── SocketService.ts
+└── server.ts
+```
+
+## Tests
+
+```bash
+npm run test:unit
+npm run test:integration  # requiert PostgreSQL + Redis
+npm run test:coverage     # seuil 70%
+```
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*

--- a/voyage/README.md
+++ b/voyage/README.md
@@ -1,0 +1,190 @@
+# Voyage Service
+
+> **Service voyage** — Recherche et réservation de vols, hôtels et activités via l'API Amadeus
+
+- **Port** : 3003 (`process.env.PORT || 3003`)
+- **Base de route** : `/api/v1`
+- **Health check** : `/health`, `/api/health`
+
+## Responsabilités
+
+- Recherche de vols, hôtels et activités via l'API Amadeus
+- Gestion du panier multi-items (CartData, CartItem)
+- Gestion des réservations et de leur cycle de vie
+- Construction et gestion des itinéraires de voyage
+- Historique des recherches (SearchHistory)
+- Pattern Saga : écoute les événements de paiement pour confirmer/annuler les réservations
+
+## Stack
+
+| Technologie | Rôle |
+|-------------|------|
+| Express 4 + TypeScript | Framework HTTP |
+| Prisma + PostgreSQL | Persistance (via `@dreamscape/db`) |
+| Redis | Cache des résultats de recherche |
+| Amadeus SDK | API vols, hôtels, activités |
+| kafkajs (`@dreamscape/kafka`) | Événements async + Saga Pattern |
+| axios | Appels HTTP inter-services |
+| helmet, CORS, rate-limit | Sécurité |
+
+## Endpoints
+
+### Vols (Amadeus)
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/flights/search` | Recherche de vols |
+| `GET` | `/api/v1/flights/:id` | Détail d'un vol |
+| `POST` | `/api/v1/flights/price` | Vérification du prix en temps réel |
+
+### Hôtels (Amadeus)
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/hotels/search` | Recherche d'hôtels |
+| `GET` | `/api/v1/hotels/:id` | Détail d'un hôtel |
+| `GET` | `/api/v1/hotels/:id/offers` | Offres disponibles |
+
+### Activités (Amadeus)
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/activities/search` | Recherche d'activités |
+| `GET` | `/api/v1/activities/:id` | Détail d'une activité |
+
+### Panier
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/cart` | Récupérer le panier |
+| `POST` | `/api/v1/cart/items` | Ajouter un item au panier |
+| `PUT` | `/api/v1/cart/items/:id` | Modifier un item |
+| `DELETE` | `/api/v1/cart/items/:id` | Supprimer un item |
+| `POST` | `/api/v1/cart/checkout` | Passer à la réservation |
+
+### Réservations
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/bookings` | Liste des réservations |
+| `GET` | `/api/v1/bookings/:id` | Détail d'une réservation |
+| `POST` | `/api/v1/bookings` | Créer une réservation |
+| `PUT` | `/api/v1/bookings/:id/cancel` | Annuler une réservation |
+
+### Itinéraires
+| Méthode | Route | Description |
+|---------|-------|-------------|
+| `GET` | `/api/v1/itineraries` | Liste des itinéraires |
+| `POST` | `/api/v1/itineraries` | Créer un itinéraire |
+| `PUT` | `/api/v1/itineraries/:id` | Modifier un itinéraire |
+| `DELETE` | `/api/v1/itineraries/:id` | Supprimer un itinéraire |
+
+## Quick Start
+
+```bash
+npm install
+cp .env.example .env
+npm run dev      # hot reload via tsx watch
+```
+
+## Variables d'environnement
+
+```env
+NODE_ENV=development
+PORT=3003
+DATABASE_URL=postgresql://dreamscape_user:password@localhost:5432/dreamscape
+JWT_SECRET=your-super-secret-jwt-key
+REDIS_HOST=localhost
+REDIS_PORT=6379
+CORS_ORIGIN=http://localhost:5173
+KAFKA_BROKERS=localhost:9092
+AMADEUS_API_KEY=your-amadeus-key
+AMADEUS_API_SECRET=your-amadeus-secret
+AMADEUS_HOSTNAME=test    # 'test' ou 'production'
+```
+
+> L'API Amadeus en environnement `test` a des limitations (données simulées, destinations restreintes). Voir `dreamscape-docs/reference/amadeus-test-limitations.md`.
+
+## Événements Kafka
+
+**Publiés** :
+| Topic | Déclencheur |
+|-------|-------------|
+| `dreamscape.voyage.booking.created` | Nouvelle réservation |
+| `dreamscape.voyage.booking.cancelled` | Annulation |
+| `dreamscape.voyage.booking.confirmed` | Confirmation post-paiement |
+| `dreamscape.voyage.search.performed` | Recherche effectuée |
+| `dreamscape.voyage.cart.item.added` | Ajout au panier |
+
+**Consommés (Saga Pattern)** :
+| Topic | Action |
+|-------|--------|
+| `dreamscape.payment.completed` | Confirmer la réservation |
+| `dreamscape.payment.failed` | Annuler la réservation |
+
+> Tickets Jira : DR-402 (publish), DR-403 (consume), DR-391/392 (Saga)
+
+## Saga Pattern — Gestion des réservations
+
+Le Voyage Service joue le rôle d'orchestrateur dans le Saga Pattern :
+
+```
+1. Client → POST /cart/checkout
+2. Voyage Service → publie dreamscape.voyage.booking.created
+3. Payment Service → démarre le paiement Stripe
+4. Payment Service → publie dreamscape.payment.completed/failed
+5. Voyage Service → confirme ou annule la réservation
+```
+
+## Cache Redis
+
+Les résultats de recherche Amadeus sont mis en cache pour réduire les appels API :
+
+- Recherche vols : TTL 5 minutes
+- Recherche hôtels : TTL 10 minutes
+- Recherche activités : TTL 15 minutes
+
+Le service démarre sans Redis (dégradation gracieuse) mais les performances sont réduites.
+
+## Structure du code
+
+```
+src/
+├── config/
+│   ├── environment.ts
+│   └── redis.ts
+├── database/
+│   └── DatabaseService.ts
+├── handlers/
+│   └── paymentEventsHandler.ts   # Saga consumer
+├── middleware/
+│   ├── auth.ts
+│   ├── errorHandler.ts
+│   └── rateLimiter.ts
+├── routes/
+│   ├── flights.ts
+│   ├── hotels.ts
+│   ├── activities.ts
+│   ├── cart.ts
+│   ├── bookings.ts
+│   ├── itineraries.ts
+│   └── health.ts
+├── services/
+│   ├── AmadeusService.ts
+│   ├── KafkaService.ts
+│   └── CacheService.ts
+└── server.ts
+```
+
+## Tests
+
+```bash
+npm run test:unit
+npm run test:integration
+npm run test:coverage
+
+# Depuis dreamscape-tests/
+npm run test:e2e:voyage
+npm run test:dr61             # Tests intégration Amadeus
+npm run test:dr67             # Tests hôtels Amadeus
+npm run test:dr69             # Tests activités Amadeus
+```
+
+---
+
+*Propriétaire et confidentiel © DreamScape 2025*


### PR DESCRIPTION
## Summary

- Mise à jour du README principal : ajout du package `@dreamscape/kafka`, Saga Pattern, Big Pods, infos DB corrigées
- Création `auth/README.md` : port 3001, JWT, Redis sessions, Kafka DR-374/375, tous les endpoints
- Création `user/README.md` : port 3002, Socket.io, GDPR, onboarding, notifications temps réel, Kafka
- Création `voyage/README.md` : port 3003, Amadeus, Saga Pattern, panier, itinéraires, Kafka DR-391/402
- Création `payment/README.md` : port 3004, Stripe, webhooks idempotents, Kafka DR-378/379
- Création `shared/README.md` : package @dreamscape/kafka, instruction rebuild obligatoire, tous les topics

## Test plan

- [ ] Vérifier la cohérence des endpoints documentés avec les routes dans le code
- [ ] Vérifier les topics Kafka listés correspondent à `shared/kafka/src/config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)