### PR TITLE
feat(US-CORE-003): Password reset backend — forgot-password & reset-password API

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@dreamscape/db": "file:../db",
     "@dreamscape/kafka": "file:../shared/kafka",
+    "@sendgrid/mail": "^8.1.6",
     "axios": "^1.6.2",
     "bcryptjs": "^3.0.2",
     "compression": "^1.7.4",

--- a/auth/src/routes/auth.ts
+++ b/auth/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { AuthService } from '@services/AuthService';
 import { authenticateToken, authenticateRefreshToken, AuthRequest } from '@middleware/auth';
 import { loginLimiter, registerLimiter, refreshLimiter } from '@middleware/rateLimiter';
 import authKafkaService from '@services/KafkaService';
+import * as PasswordResetService from '@services/PasswordResetService';
 
 const router = express.Router();
 
@@ -470,5 +471,49 @@ router.post('/test/cleanup', async (req, res) => {
   const result = await AuthService.resetTestData();
   res.status(200).json(result);
 });
+
+// POST /api/v1/auth/forgot-password
+router.post(
+  '/forgot-password',
+  conditionalRateLimit(loginLimiter),
+  [body('email').isEmail().normalizeEmail().withMessage('Please provide a valid email address')],
+  async (req: express.Request, res: express.Response) => {
+    if (handleValidationErrors(req, res)) return;
+    try {
+      const result = await PasswordResetService.requestPasswordReset(req.body.email);
+      res.json(result);
+    } catch (error) {
+      console.error('Forgot password route error:', error);
+      res.status(500).json({ success: false, message: 'Internal server error' });
+    }
+  }
+);
+
+// PUT /api/v1/auth/reset-password
+router.put(
+  '/reset-password',
+  [
+    body('token').notEmpty().withMessage('Token is required'),
+    body('newPassword')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters long')
+      .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/)
+      .withMessage('Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'),
+  ],
+  async (req: express.Request, res: express.Response) => {
+    if (handleValidationErrors(req, res)) return;
+    try {
+      const result = await PasswordResetService.resetPassword(req.body.token, req.body.newPassword);
+      res.json(result);
+    } catch (error: any) {
+      if (error.message === 'Invalid or expired token') {
+        res.status(400).json({ success: false, message: error.message });
+        return;
+      }
+      console.error('Reset password route error:', error);
+      res.status(500).json({ success: false, message: 'Internal server error' });
+    }
+  }
+);
 
 export default router;

--- a/auth/src/services/EmailService.ts
+++ b/auth/src/services/EmailService.ts
@@ -1,0 +1,70 @@
+import sgMail from '@sendgrid/mail';
+
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || 'noreply@dreamscape.app';
+const SENDGRID_FROM_NAME = process.env.SENDGRID_FROM_NAME || 'Dreamscape';
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
+
+export function isSendGridConfigured(): boolean {
+  return !!SENDGRID_API_KEY && SENDGRID_API_KEY !== 'your-sendgrid-api-key-here';
+}
+
+if (SENDGRID_API_KEY && isSendGridConfigured()) {
+  sgMail.setApiKey(SENDGRID_API_KEY);
+}
+
+interface SendEmailParams {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+}
+
+export async function sendEmail(params: SendEmailParams): Promise<void> {
+  if (!isSendGridConfigured()) {
+    throw new Error('SENDGRID_NOT_CONFIGURED');
+  }
+
+  await sgMail.send({
+    to: params.to,
+    from: { email: SENDGRID_FROM_EMAIL, name: SENDGRID_FROM_NAME },
+    subject: params.subject,
+    text: params.text,
+    html: params.html || params.text,
+  });
+}
+
+export async function sendPasswordResetEmail(params: {
+  to: string;
+  userName: string;
+  resetLink: string;
+}): Promise<void> {
+  const { to, userName, resetLink } = params;
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <h2 style="color: #f97316;">Réinitialisation de votre mot de passe — Dreamscape</h2>
+      <p>Bonjour ${userName},</p>
+      <p>Vous avez demandé la réinitialisation de votre mot de passe. Cliquez sur le bouton ci-dessous pour créer un nouveau mot de passe :</p>
+      <div style="text-align: center; margin: 32px 0;">
+        <a href="${resetLink}"
+           style="background-color: #f97316; color: white; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: bold; display: inline-block;">
+          Réinitialiser mon mot de passe
+        </a>
+      </div>
+      <p style="color: #6b7280; font-size: 14px;">Ce lien est valable pendant <strong>24 heures</strong>.</p>
+      <p style="color: #6b7280; font-size: 14px;">Si vous n'avez pas demandé cette réinitialisation, ignorez cet email. Votre mot de passe restera inchangé.</p>
+      <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+      <p style="color: #9ca3af; font-size: 12px;">L'équipe Dreamscape</p>
+    </div>
+  `;
+
+  await sendEmail({
+    to,
+    subject: 'Réinitialisation de votre mot de passe — Dreamscape',
+    text: `Bonjour ${userName},\n\nVous avez demandé la réinitialisation de votre mot de passe.\n\nCliquez sur ce lien pour créer un nouveau mot de passe (valable 24h) :\n${resetLink}\n\nSi vous n'avez pas fait cette demande, ignorez cet email.\n\nL'équipe Dreamscape`,
+    html,
+  });
+}
+
+export { FRONTEND_URL };

--- a/auth/src/services/PasswordResetService.ts
+++ b/auth/src/services/PasswordResetService.ts
@@ -1,0 +1,70 @@
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@dreamscape/db';
+import { isSendGridConfigured, sendPasswordResetEmail, FRONTEND_URL } from './EmailService';
+
+export async function requestPasswordReset(email: string): Promise<{ success: boolean }> {
+  // Always return success to prevent email enumeration
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+
+  if (!user) {
+    return { success: true };
+  }
+
+  // Invalidate all existing unused tokens for this user
+  await prisma.passwordReset.updateMany({
+    where: { userId: user.id, used: false },
+    data: { used: true },
+  });
+
+  // Generate a secure random token
+  const token = crypto.randomBytes(32).toString('hex');
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+
+  await prisma.passwordReset.create({
+    data: { userId: user.id, token, expiresAt },
+  });
+
+  const resetLink = `${FRONTEND_URL}/reset-password?token=${token}`;
+  const userName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.email;
+
+  if (isSendGridConfigured()) {
+    await sendPasswordResetEmail({ to: user.email, userName, resetLink });
+  } else {
+    console.log(`[DEV] Password reset link for ${user.email}: ${resetLink}`);
+  }
+
+  return { success: true };
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<{ success: boolean }> {
+  const record = await prisma.passwordReset.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+
+  if (!record || record.used || record.expiresAt < new Date()) {
+    throw new Error('Invalid or expired token');
+  }
+
+  const hashedPassword = await bcrypt.hash(newPassword, 12);
+
+  await prisma.user.update({
+    where: { id: record.userId },
+    data: { password: hashedPassword },
+  });
+
+  // Mark token as used
+  await prisma.passwordReset.update({
+    where: { token },
+    data: { used: true },
+  });
+
+  // Force logout all sessions (security: revoke all active sessions)
+  await prisma.session.deleteMany({ where: { userId: record.userId } });
+
+  return { success: true };
+}

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -60,6 +60,9 @@ model User {
   // Notifications (DR-446)
   notifications Notification[]
 
+  // Password reset
+  passwordResets PasswordReset[]
+
   @@map("users")
 }
 
@@ -690,6 +693,18 @@ model TokenBlacklist {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("token_blacklist")
+}
+
+model PasswordReset {
+  id        String   @id @default(cuid())
+  userId    String
+  token     String   @unique
+  expiresAt DateTime
+  used      Boolean  @default(false)
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("password_resets")
 }
 
 enum Role {


### PR DESCRIPTION
## Summary
- Ajout du modèle `PasswordReset` dans le schéma Prisma (token unique, expiry 24h, flag `used`, cascade on delete)
- `EmailService.ts` dans le auth service avec `sendPasswordResetEmail()` via SendGrid (log console si non configuré)
- `PasswordResetService.ts` : `requestPasswordReset()` (anti-énumération) + `resetPassword()` (invalide le token, force logout toutes les sessions)
- `POST /auth/forgot-password` et `PUT /auth/reset-password` avec validation et rate limiting

## ⚠️ Action manuelle requise
Lancer `npx prisma db push` depuis `dreamscape-services/db/` pour créer la table `password_resets`.

## Test plan
- [ ] `POST /forgot-password` avec email existant → lien dans les logs console
- [ ] `POST /forgot-password` avec email inexistant → 200 (anti-énumération)
- [ ] `PUT /reset-password` avec token valide + mot de passe fort → 200 + sessions révoquées
- [ ] `PUT /reset-password` avec token déjà utilisé → 400
- [ ] `PUT /reset-password` avec mot de passe faible → 400
